### PR TITLE
Allow to pass supplementary arguments and relax device constraints

### DIFF
--- a/configs/online-vdev.toml
+++ b/configs/online-vdev.toml
@@ -1,0 +1,45 @@
+
+#This configuration is an example to show how to use a DPDK virtual device
+# for instance af_packet sockets, memory ring, or pcap-backed device.
+#!!!Those virtual devices do not expose hardware capabilities, this is only
+# intended for limited functional testing. !!!
+
+main_core = 0
+nb_memory_channels = 6
+
+[mempool]
+    capacity = 8192
+    cache_size = 512
+
+[online]
+    duration = 60
+    nb_rxd = 32768
+    promiscuous = true
+    mtu = 1500
+    hardware_assist = false
+    dpdk_supl_args = ["--no-huge","--no-pci","-m 512M","--vdev=net_pcap0,iface=ens0"]
+
+    [online.monitor.display]
+        throughput = true
+        mempool_usage = true
+        port_stats = ["rx_good_packets",
+                        "rx_good_bytes",
+                        "rx_mbuf_allocation_errors",
+                        "rx_phy_discard_packets",
+                        "rx_missed_errors",
+                        ]
+    [online.monitor.log]
+        directory = "./log"
+        interval = 1000
+
+    [[online.ports]]
+        device = "net_pcap0"
+        cores = [1]
+
+[conntrack]
+    max_connections = 10_000_000
+    max_out_of_order = 500
+    timeout_resolution = 100
+    udp_inactivity_timeout = 60_000
+    tcp_inactivity_timeout = 300_000
+    tcp_establish_timeout = 5000

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -139,6 +139,9 @@ impl RuntimeConfig {
         eal_params.push(core_list.join(","));
 
         if let Some(online) = &self.online {
+            for supl_arg in online.dpdk_supl_args.iter() {
+                eal_params.push(supl_arg.to_string())
+            }
             for port in online.ports.iter() {
                 eal_params.push("-a".to_owned());
                 eal_params.push(port.device.to_string());
@@ -260,6 +263,7 @@ fn default_cache_size() -> usize {
 ///     promiscuous = true
 ///     mtu = 1500
 ///     hardware_assist = true
+///     dpdk_supl_args = []
 ///
 /// [online.monitor.display]
 ///     throughput = true
@@ -306,6 +310,12 @@ pub struct OnlineConfig {
     #[serde(default = "default_hardware_assist")]
     pub hardware_assist: bool,
 
+    /// If set, will pass supplementary arguments to DPDK EAL (see DPDK
+    /// configuration). For instance "--no-huge".
+    /// Defaults to empty string.
+    #[serde(default = "default_dpdk_supl_args")]
+    pub dpdk_supl_args: Vec<String>,
+
     /// Live performance monitoring. Defaults to `None`.
     #[serde(default = "default_monitor")]
     pub monitor: Option<MonitorConfig>,
@@ -320,6 +330,10 @@ fn default_duration() -> Option<u64> {
 
 fn default_hardware_assist() -> bool {
     true
+}
+
+fn default_dpdk_supl_args() -> Vec<String> {
+    Vec::new()
 }
 
 fn default_promiscuous() -> bool {

--- a/core/src/lcore/monitor.rs
+++ b/core/src/lcore/monitor.rs
@@ -306,21 +306,33 @@ impl AggRxStats {
                     // Ingress (reached NIC)
                     ingress_bytes += match port_stats.stats.get("rx_phy_bytes") {
                         Some(v) => *v,
-                        None => bail!("Failed retrieving ingress_bytes"),
+                        None => {
+                            log::warn!("Failed retrieving ingress_bytes, device does not support precise PHY count");
+                            0
+                        }
                     };
                     ingress_pkts += match port_stats.stats.get("rx_phy_packets") {
                         Some(v) => *v,
-                        None => bail!("Failed retrieving ingress_pkts"),
+                        None => {
+                            log::warn!("Failed retrieving ingress_pkts, device does not support precise PHY count");
+                            0
+                        }
                     };
 
                     // Good (reached software)
                     let good_bytes_temp = match port_stats.stats.get("rx_good_bytes") {
                         Some(v) => *v,
-                        None => bail!("Failed retrieving good_bytes"),
+                        None => {
+                            log::warn!("Failed retrieving good_bytes, device does not support precise PHY count");
+                            0
+                        }
                     };
                     let good_pkts_temp = match port_stats.stats.get("rx_good_packets") {
                         Some(v) => *v,
-                        None => bail!("Failed retrieving good_pkts"),
+                        None => {
+                            log::warn!("Failed retrieving good_pkts, device does not support precise PHY count");
+                            0
+                        }
                     };
                     good_bytes += good_bytes_temp;
                     good_pkts += good_pkts_temp;
@@ -350,7 +362,10 @@ impl AggRxStats {
                     // dropped
                     hw_dropped_pkts += match port_stats.stats.get("rx_phy_discard_packets") {
                         Some(v) => *v,
-                        None => bail!("Failed retrieving hw_dropped_pkts"),
+                        None => {
+                            log::warn!("Failed retrieving hw_dropped_pkts, device does not support precise packet dropped counter (no hardware drop will be accounted for).");
+                            0
+                        }
                     };
                     sw_dropped_pkts += match port_stats.stats.get("rx_missed_errors") {
                         Some(v) => *v,


### PR DESCRIPTION
Add the dpdk_supl_args argument to pass arguments such as ["--no-huge","--no-pci"] allowing to try Retina in restricted environment, i.e. with Docker using PCAP virtual device (https://doc.dpdk.org/guides/nics/pcap_ring.html).

Also, if RSS is not supported do not fail but warn the user.

Similarly, if some statistics are not available, do not fail but warn
the user.

Verify that the MTU is in the device constraint. If setting it is not
supported, do not fail but warn user.

Verify the VLAN_STRIP offload is possible. If not, just don't activate
it.