### PR TITLE
Reduce output

### DIFF
--- a/configs/offline.toml
+++ b/configs/offline.toml
@@ -1,8 +1,8 @@
 main_core = 0
-nb_memory_channels = 6 
+nb_memory_channels = 6
 
 [mempool]
-    capacity = 262144
+    capacity = 262_144
     cache_size = 512
 
 [offline]

--- a/configs/online.toml
+++ b/configs/online.toml
@@ -1,5 +1,5 @@
 main_core = 0
-nb_memory_channels = 6 
+nb_memory_channels = 6
 
 [mempool]
     capacity = 8_388_608
@@ -7,7 +7,7 @@ nb_memory_channels = 6
 
 [online]
     duration = 60
-    nb_rxd = 32768
+    nb_rxd = 32_768
     promiscuous = true
     mtu = 1500
     hardware_assist = true
@@ -30,16 +30,10 @@ nb_memory_channels = 6
     [[online.ports]]
         device = "0000:3b:00.0"
         cores = [1,2,3,4,5,6,7,8]
-#        [online.ports.sink]
-#            core = 23
-#            nb_buckets = 512
 
-    # [[online.ports]]
-    #     device = "0000:d8:00.0"
-    #     cores = [1]
-    #     [online.ports.sink]
-    #         core = 40
-    #         nb_buckets = 512
+    [[online.ports]]
+        device = "0000:d8:00.0"
+        cores = [9,10,11,12,13,14,15,16]
 
 [conntrack]
     max_connections = 10_000_000

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -54,6 +54,10 @@ pub struct RuntimeConfig {
     #[serde(default = "default_nb_memory_channels")]
     pub nb_memory_channels: usize,
 
+    /// Suppress DPDK runtime logging and telemetry output. Defaults to `true`.
+    #[serde(default = "default_suppress_dpdk_output")]
+    pub suppress_dpdk_output: bool,
+
     /// Per-mempool settings.
     pub mempool: MempoolConfig,
 
@@ -128,12 +132,21 @@ impl RuntimeConfig {
         eal_params.push("-n".to_owned());
         eal_params.push(self.nb_memory_channels.to_string());
 
+        if self.suppress_dpdk_output {
+            eal_params.push("--log-level=6".to_owned());
+            eal_params.push("--no-telemetry".to_owned());
+        }
+
         eal_params
     }
 }
 
 fn default_nb_memory_channels() -> usize {
     1
+}
+
+fn default_suppress_dpdk_output() -> bool {
+    true
 }
 
 fn default_online() -> Option<OnlineConfig> {
@@ -153,8 +166,9 @@ impl Default for RuntimeConfig {
         RuntimeConfig {
             main_core: 0,
             nb_memory_channels: 1,
+            suppress_dpdk_output: true,
             mempool: MempoolConfig {
-                capacity: 65536,
+                capacity: 65_536,
                 cache_size: 512,
             },
             online: None,

--- a/filtergen/src/lib.rs
+++ b/filtergen/src/lib.rs
@@ -152,7 +152,8 @@ pub fn filter(args: TokenStream, input: TokenStream) -> TokenStream {
 
     let mut ptree = filter.to_ptree();
     ptree.prune_branches();
-    println!("{}", ptree);
+    // Displays the predicate trie during compilation.
+    // println!("{}", ptree);
 
     // store lazily evaluated statics like pre-compiled Regex
     let mut statics: Vec<proc_macro2::TokenStream> = vec![];


### PR DESCRIPTION
Adds a configuration option to suppress DPDK runtime log and telemetry outputs.
Removes predicate trie display during compilation to avoid clutter.