### PR TITLE
Spin example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,14 +2,15 @@
 members = [
     "core",
     "examples/basic",
-    "examples/ip_anon",
     "examples/client_randoms",
+    "examples/ip_anon",
     "examples/log_conn",
     "examples/log_tls",
     "examples/log_http",
     "examples/log_dns",
     "examples/log_tls",
     "examples/pcap_dump",
+    "examples/spin",
     "examples/video",
     "filtergen",
 ]

--- a/core/src/dpdk/mod.rs
+++ b/core/src/dpdk/mod.rs
@@ -120,6 +120,13 @@ pub unsafe fn rte_lcore_id() -> u16 {
     rte_lcore_id_()
 }
 
+/// Reads the timestamp counter (TSC) register.
+///
+/// This is a low-overhead way to get CPU timing information, but may not be available on all
+/// platforms and could be imprecise. It should only be used to approximate cycle counts.
+///
+/// ## Remarks
+/// This is `unsafe` because it calls the DPDK `rte_rdtsc()` function via FFI. Use at your own risk.
 #[inline]
 pub unsafe fn rte_rdtsc() -> u64 {
     rte_rdtsc_()

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -48,7 +48,7 @@ pub mod config;
 mod conntrack;
 #[doc(hidden)]
 #[allow(clippy::all)]
-pub mod dpdk;
+mod dpdk;
 // The filter module must be public to be accessible by the filter_gen procedural macro crate.
 // However, module functions should be opaque to users, so documentation is hidden by default.
 #[doc(hidden)]
@@ -64,6 +64,8 @@ pub mod utils;
 pub use self::conntrack::conn_id::{ConnId, FiveTuple};
 pub use self::memory::mbuf::Mbuf;
 pub use self::runtime::Runtime;
+
+pub use dpdk::rte_rdtsc;
 
 #[macro_use]
 extern crate pest_derive;

--- a/core/src/runtime/mod.rs
+++ b/core/src/runtime/mod.rs
@@ -64,6 +64,7 @@ where
             Filter::from_str(factory.filter_str.as_str(), true).expect("Failed to parse filter");
         let subscription = Arc::new(Subscription::new(factory, cb));
 
+        println!("Initializing Retina runtime...");
         log::info!("Initializing EAL...");
         dpdk::load_drivers();
         {

--- a/examples/spin/Cargo.toml
+++ b/examples/spin/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "spin"
+version = "0.1.0"
+edition = "2021"
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1.0.40"
+clap = { version = "3.1.8", features = ["derive"] }
+env_logger = "0.8.3"
+log = { version = "0.4", features = ["release_max_level_info"] }
+retina-core = { path = "../../core" }
+retina-filtergen = { path = "../../filtergen" }

--- a/examples/spin/README.md
+++ b/examples/spin/README.md
@@ -1,7 +1,10 @@
 # Spin cycles
 
-Busy loops inside the callback for a given number of cycles.
-This varies the per-callback processing time and approximates the impact of increasing callback complexity.
+Busy loops inside the callback for a given number of cycles. This varies the per-callback processing
+time and approximates the impact of increasing callback complexity.
+
+To view the effects of busy looping, run Retina in online mode with live monitoring
+display enabled and observe the packet drop rate.
 
 ### Build and run
 ```

--- a/examples/spin/README.md
+++ b/examples/spin/README.md
@@ -3,11 +3,17 @@
 Busy loops inside the callback for a given number of cycles. This varies the per-callback processing
 time and approximates the impact of increasing callback complexity.
 
-To view the effects of busy looping, run Retina in online mode with live monitoring
-display enabled and observe the packet drop rate.
+To view the effects of busy looping, run Retina in online mode with live monitoring display enabled
+and observe the packet drop rate.
 
 ### Build and run
 ```
 cargo build --release --bin spin
 sudo env LD_LIBRARY_PATH=$LD_LIBRARY_PATH RUST_LOG=error ./target/release/spin -c <path/to/config.toml> --spin <num_cycles>
 ```
+
+### Remarks
+This makes use of the [unsafe](https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html)
+`rte_rdtsc()` function to read the Time Stamp Counter (TSC) register. This is a low-overhead way to
+get CPU timing information, but may be imprecise and should only be used to approximate cycle
+counts.

--- a/examples/spin/README.md
+++ b/examples/spin/README.md
@@ -1,0 +1,10 @@
+# Spin cycles
+
+Busy loops inside the callback for a given number of cycles.
+This varies the per-callback processing time and approximates the impact of increasing callback complexity.
+
+### Build and run
+```
+cargo build --release --bin spin
+sudo env LD_LIBRARY_PATH=$LD_LIBRARY_PATH RUST_LOG=error ./target/release/spin -c <path/to/config.toml> --spin <num_cycles>
+```

--- a/examples/spin/src/main.rs
+++ b/examples/spin/src/main.rs
@@ -4,9 +4,9 @@ use retina_core::subscription::*;
 use retina_core::Runtime;
 use retina_filtergen::filter;
 
-use std::path::PathBuf;
 use anyhow::Result;
 use clap::Parser;
+use std::path::PathBuf;
 
 #[derive(Parser, Debug)]
 struct Args {

--- a/examples/spin/src/main.rs
+++ b/examples/spin/src/main.rs
@@ -1,5 +1,5 @@
 use retina_core::config::load_config;
-use retina_core::dpdk;
+use retina_core::rte_rdtsc;
 use retina_core::subscription::*;
 use retina_core::Runtime;
 use retina_filtergen::filter;
@@ -36,9 +36,9 @@ fn spin(cycles: u64) {
     if cycles == 0 {
         return;
     }
-    let start = unsafe { dpdk::rte_rdtsc() };
+    let start = unsafe { rte_rdtsc() };
     loop {
-        let now = unsafe { dpdk::rte_rdtsc() };
+        let now = unsafe { rte_rdtsc() };
         if now - start > cycles {
             break;
         }

--- a/examples/spin/src/main.rs
+++ b/examples/spin/src/main.rs
@@ -1,0 +1,46 @@
+use retina_core::config::load_config;
+use retina_core::dpdk;
+use retina_core::subscription::*;
+use retina_core::Runtime;
+use retina_filtergen::filter;
+
+use std::path::PathBuf;
+use anyhow::Result;
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+struct Args {
+    #[clap(short, long, parse(from_os_str), value_name = "FILE")]
+    config: PathBuf,
+    #[clap(short, long)]
+    spin: u64,
+}
+
+#[filter("tls")]
+fn main() -> Result<()> {
+    env_logger::init();
+    let args = Args::parse();
+    let config = load_config(&args.config);
+
+    let cycles = args.spin;
+    let callback = |_: TlsHandshake| {
+        spin(cycles);
+    };
+    let mut runtime = Runtime::new(config, filter, callback)?;
+    runtime.run();
+    Ok(())
+}
+
+#[inline]
+fn spin(cycles: u64) {
+    if cycles == 0 {
+        return;
+    }
+    let start = unsafe { dpdk::rte_rdtsc() };
+    loop {
+        let now = unsafe { dpdk::rte_rdtsc() };
+        if now - start > cycles {
+            break;
+        }
+    }
+}


### PR DESCRIPTION
Reduces visibility of the DPDK module to crate-private.
Adds an example to approximate callback complexity by busy looping for a given number of cycles.
