### PR TITLE
VDEV: Set default MTU to 65535

### DIFF
--- a/configs/online-vdev.toml
+++ b/configs/online-vdev.toml
@@ -15,7 +15,7 @@ nb_memory_channels = 6
     duration = 60
     nb_rxd = 32768
     promiscuous = true
-    mtu = 1500
+    mtu = 65535
     hardware_assist = false
     dpdk_supl_args = ["--no-huge","--no-pci","-m 512M","--vdev=net_pcap0,iface=ens0"]
 


### PR DESCRIPTION
In general VDEVs are not able to change the MTU, and do not support scattering. So if GRO is enabled packets will be truncated and malformed.

@thegwan is there a way to support truncated packets? It would be interesting as traces are often truncated too.