### PR TITLE
More accessor methods for IPv4 and TCP modules

### DIFF
--- a/core/src/protocols/packet/ipv4.rs
+++ b/core/src/protocols/packet/ipv4.rs
@@ -8,7 +8,16 @@ use std::net::Ipv4Addr;
 
 use anyhow::{bail, Result};
 
+/// IPv4 EtherType
 const IPV4_PROTOCOL: usize = 0x0800;
+/// Flag: "Reserved bit"
+const IPV4_RF: u16 = 0x8000;
+/// Flag: "Don't fragment"
+const IPV4_DF: u16 = 0x4000;
+/// Flag: "More fragments"
+const IPV4_MF: u16 = 0x2000;
+/// Fragment offset part
+const IPV4_FRAG_OFFSET: u16 = 0x1FFF;
 
 /// An IPv4 packet.
 ///
@@ -82,6 +91,36 @@ impl<'a> Ipv4<'a> {
     #[inline]
     pub fn flags_to_fragment_offset(&self) -> u16 {
         self.header.flags_to_fragment_offset.into()
+    }
+
+    /// Returns the 3-bit IP flags.
+    #[inline]
+    pub fn flags(&self) -> u8 {
+        (self.flags_to_fragment_offset() >> 13) as u8
+    }
+
+    /// Returns `true` if the Reserved flag is set.
+    #[inline]
+    pub fn rf(&self) -> bool {
+        (self.flags_to_fragment_offset() & IPV4_RF) != 0
+    }
+
+    /// Returns `true` if the Don't Fragment flag is set.
+    #[inline]
+    pub fn df(&self) -> bool {
+        (self.flags_to_fragment_offset() & IPV4_DF) != 0
+    }
+
+    /// Returns `true` if the More Fragments flag is set.
+    #[inline]
+    pub fn mf(&self) -> bool {
+        (self.flags_to_fragment_offset() & IPV4_MF) != 0
+    }
+
+    /// Returns the fragment offset in units of 8 bytes.
+    #[inline]
+    pub fn fragment_offset(&self) -> u16 {
+        self.flags_to_fragment_offset() & IPV4_FRAG_OFFSET
     }
 
     /// Returns the time to live (TTL) of the packet.

--- a/core/src/protocols/packet/tcp.rs
+++ b/core/src/protocols/packet/tcp.rs
@@ -63,27 +63,37 @@ impl<'a> Tcp<'a> {
         (self.header.data_offset_to_ns & 0xf0) >> 4
     }
 
+    /// Returns the reserved bits.
+    #[inline]
+    pub fn reserved(&self) -> u8 {
+        self.header.data_offset_to_ns & 0x0f
+    }
+
     /// Returns the 8-bit field containing the data offset, 3 reserved bits, and the nonce sum bit.
     #[inline]
     pub fn data_offset_to_ns(&self) -> u8 {
         self.header.data_offset_to_ns
     }
 
+    /// Returns the 8-bit TCP flags.
     #[inline]
     pub fn flags(&self) -> u8 {
         self.header.flags
     }
 
+    /// Returns the size of the receive window in window size units.
     #[inline]
     pub fn window(&self) -> u16 {
         self.header.window.into()
     }
 
+    /// Returns the 16-bit checksum field.
     #[inline]
     pub fn checksum(&self) -> u16 {
         self.header.checksum.into()
     }
 
+    /// Returns the urgent pointer.
     #[inline]
     pub fn urgent_pointer(&self) -> u16 {
         self.header.urgent_pointer.into()
@@ -91,7 +101,7 @@ impl<'a> Tcp<'a> {
 
     // ------------------------------------------------
 
-    /// Returns `true` if the nonce sum flag is set.
+    /// Returns `true` if the (historical) nonce sum flag is set.
     #[inline]
     pub fn ns(&self) -> bool {
         (self.header.data_offset_to_ns & 0x01) != 0


### PR DESCRIPTION
- For convenience, adds some more accessor methods for IPv4 and TCP header fields.
- Adds some missing documentation.
