### PR TITLE
Update rustdoc CI rustc version to 1.75.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,8 @@ jobs:
             echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH" >> $GITHUB_ENV
             echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH" >> $GITHUB_ENV
             echo "DPDK_PATH=$DPDK_PATH" >> $GITHUB_ENV
+    - name: Remove LLVM 14 and Clang 14
+      run: sudo apt remove --auto-remove clang-14 llvm-14
 
     - name: Clippy retina-core (no mlx5)
       run: cargo clippy --manifest-path core/Cargo.toml --no-default-features -- --deny warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
             echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH" >> $GITHUB_ENV
             echo "DPDK_PATH=$DPDK_PATH" >> $GITHUB_ENV
     - name: Remove LLVM 14 and Clang 14
-      run: sudo apt remove --auto-remove clang-14 llvm-14
+      run: sudo apt remove --auto-remove clang-14 llvm-14 && sudo apt remove --auto-remove clang-13 llvm-13;
 
     - name: Clippy retina-core (no mlx5)
       run: cargo clippy --manifest-path core/Cargo.toml --no-default-features -- --deny warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
             echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH" >> $GITHUB_ENV
             echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH" >> $GITHUB_ENV
             echo "DPDK_PATH=$DPDK_PATH" >> $GITHUB_ENV
-    - name: Remove LLVM 14 and Clang 14
+    - name: Remove LLVM and Clang 13/14
       run: sudo apt remove --auto-remove clang-14 llvm-14 && sudo apt remove --auto-remove clang-13 llvm-13;
 
     - name: Clippy retina-core (no mlx5)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Install Rust stable
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.69.0
+        toolchain: 1.75.0
         override: true
         components: rustfmt, clippy
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Install Rust stable
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.69.0
+        toolchain: 1.75.0
         override: true
         components: rustfmt, clippy
     - name: Set up Python ${{ matrix.python-version }}  

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "examples/video",
     "filtergen",
 ]
+resolver = "2"
 
 [profile.release]
 lto = true

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [build-dependencies]
-bindgen = "0.60.1" 
+bindgen = "0.69.4" 
 cc = "1.0.79"
 
 [dependencies]

--- a/core/build.rs
+++ b/core/build.rs
@@ -99,7 +99,7 @@ fn main() {
         .allowlist_type(r"(rte|eth|pcap)_.*")
         .allowlist_function(r"(_rte|rte|eth|numa|pcap)_.*")
         .allowlist_var(r"(RTE|DEV|ETH|MEMPOOL|PKT|rte)_.*")
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
         .generate_comments(false)
         .generate()
         .unwrap_or_else(|e| panic!("Failed to generate bindings: {:?}", e));

--- a/core/src/filter/hardware/flow_action.rs
+++ b/core/src/filter/hardware/flow_action.rs
@@ -78,7 +78,7 @@ impl FlowAction {
 
         // Since the RSS key needs to outlive this method, we use the static
         // SYMMETRIC_RSS_KEY instead of the key queried from the existing rss_conf
-        a_rss_conf.key = SYMMETRIC_RSS_KEY.as_ptr() as *const u8;
+        a_rss_conf.key = SYMMETRIC_RSS_KEY.as_ptr();
 
         self.rss.push(a_rss_conf);
     }

--- a/core/src/filter/hardware/mod.rs
+++ b/core/src/filter/hardware/mod.rs
@@ -220,7 +220,7 @@ fn validate_rule(
     // Need to update flow_action_rss here
     // reta_raw needs to stay in scope until after rte_flow_validate() succeeds
     let reta_raw = port.reta.iter().map(|q| q.raw()).collect::<Vec<_>>();
-    for mut a in action.rules.iter_mut() {
+    for a in action.rules.iter_mut() {
         if let dpdk::rte_flow_action_type_RTE_FLOW_ACTION_TYPE_RSS = a.type_ {
             action.rss[0].queue_num = port.queue_map.len() as u32;
             action.rss[0].queue = reta_raw.as_ptr();
@@ -282,7 +282,7 @@ fn create_rule(
     // Need to update flow_action_rss here
     // reta_raw needs to stay in scope until after rte_flow_create() succeeds
     let reta_raw = port.reta.iter().map(|q| q.raw()).collect::<Vec<_>>();
-    for mut a in action.rules.iter_mut() {
+    for a in action.rules.iter_mut() {
         if let dpdk::rte_flow_action_type_RTE_FLOW_ACTION_TYPE_RSS = a.type_ {
             action.rss[0].queue_num = port.queue_map.len() as u32;
             action.rss[0].queue = reta_raw.as_ptr();
@@ -339,7 +339,7 @@ fn add_redirect(port: &Port, from_group: u32, to_group: u32, priority: u32) -> R
     let mut action = FlowAction::new(port.id);
     action.append_jump(to_group);
     action.finish();
-    for mut a in action.rules.iter_mut() {
+    for a in action.rules.iter_mut() {
         if let dpdk::rte_flow_action_type_RTE_FLOW_ACTION_TYPE_JUMP = a.type_ {
             a.conf = &action.jump[0] as *const _ as *const c_void;
         }

--- a/core/src/memory/mbuf.rs
+++ b/core/src/memory/mbuf.rs
@@ -85,7 +85,7 @@ impl Mbuf {
 
     /// Returns the contents of the Mbuf as a byte slice.
     pub fn data(&self) -> &[u8] {
-        let ptr = self.get_data_address(0) as *const u8;
+        let ptr = self.get_data_address(0);
         unsafe { slice::from_raw_parts(ptr, self.data_len()) as &[u8] }
     }
 
@@ -96,7 +96,7 @@ impl Mbuf {
     pub fn get_data_slice(&self, offset: usize, count: usize) -> Result<&[u8]> {
         if offset < self.data_len() {
             if offset + count <= self.data_len() {
-                let ptr = self.get_data_address(offset) as *const u8;
+                let ptr = self.get_data_address(offset);
                 unsafe { Ok(slice::from_raw_parts(ptr, count) as &[u8]) }
             } else {
                 bail!(MbufError::ReadPastBuffer)

--- a/core/src/runtime/online.rs
+++ b/core/src/runtime/online.rs
@@ -77,7 +77,7 @@ where
             for (rxqueue, core_id) in port.queue_map.iter() {
                 core_map
                     .entry(*core_id)
-                    .or_insert_with(Vec::new)
+                    .or_default()
                     .push(*rxqueue);
             }
         }

--- a/core/src/runtime/online.rs
+++ b/core/src/runtime/online.rs
@@ -75,10 +75,7 @@ where
         let mut core_map: BTreeMap<CoreId, Vec<RxQueue>> = BTreeMap::new();
         for (_port_id, port) in ports.iter() {
             for (rxqueue, core_id) in port.queue_map.iter() {
-                core_map
-                    .entry(*core_id)
-                    .or_default()
-                    .push(*rxqueue);
+                core_map.entry(*core_id).or_default().push(*rxqueue);
             }
         }
         for (core_id, rxqueues) in core_map.into_iter() {

--- a/core/src/subscription/frame.rs
+++ b/core/src/subscription/frame.rs
@@ -119,7 +119,7 @@ impl Trackable for TrackedFrame {
         if let Some(session_id) = session_id {
             self.session_buf
                 .entry(session_id)
-                .or_insert_with(Vec::new)
+                .or_default()
                 .push(pdu.mbuf_own());
         } else {
             drop(pdu);

--- a/core/src/subscription/zc_frame.rs
+++ b/core/src/subscription/zc_frame.rs
@@ -106,7 +106,7 @@ impl Trackable for TrackedZcFrame {
         if let Some(session_id) = session_id {
             self.session_buf
                 .entry(session_id)
-                .or_insert_with(Vec::new)
+                .or_default()
                 .push(pdu.mbuf_own());
         } else {
             drop(pdu);


### PR DESCRIPTION
Updates CI toolchain to Rust 1.75.0 and fixes a couple of build and clippy style warnings. 

The workspace resolver is updated to explicitly specify `resolver = "2"` to remove the build warning, see: https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions
