### PR TITLE
Fix bindgen and clang compatibility in Rustdoc workflow

### DIFF
--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -56,6 +56,8 @@ jobs:
             echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH" >> $GITHUB_ENV
             echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH" >> $GITHUB_ENV
             echo "DPDK_PATH=$DPDK_PATH" >> $GITHUB_ENV
+    - name: Remove LLVM and Clang 13/14
+      run: sudo apt remove --auto-remove clang-14 llvm-14 && sudo apt remove --auto-remove clang-13 llvm-13;
 
     - name: Build Documentation
       run: cargo doc --lib --no-deps


### PR DESCRIPTION
The default LLVM and Clang versions that come with the latest Ubuntu (22.04) in the Rustdoc workflow seems to have compatibility issues with bindgen. Removing v14.0.0 and v13.0.0 fixes the issue.