### PR TITLE
Minor config streamlining

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -126,6 +126,16 @@ Run:
 sudo env LD_LIBRARY_PATH=$LD_LIBRARY_PATH RUST_LOG=error ./target/release/my_app
 ```
 
+#### Troubleshooting: Bindgen
+
+Retina uses [bindgen](https://docs.rs/bindgen/latest/bindgen/) to generate bindings to DPDK functions implemented in C. As of 06/2024, we have encountered issues when using bindgen with clang/llvm >13, apparently due to introduced APIs for SIMD intrinsics.
+
+If you are using clang and building Retina fails with an error such as the below, downgrade clang/llvm to <=13.
+
+```sh
+error: invalid conversion between vector type '__m128i' (vector of 2 'long long' values) and integer type 'int' of different size
+```
+
 ## Testing Retina (Offline) on a VM
 
 We have deployed Retina in offline mode (streaming pcaps) on both ARM- and x86-based Ubuntu VMs. This can be useful for getting started, development, and functional testing. 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -157,8 +157,3 @@ meson setup configure -Dplatform=generic
 export LD_LIBRARY_PATH=$DPDK_PATH/lib/aarch64-linux-gnu
 ```
 
-- Similarly, in `core/build.rs`, replace `pkg_config_path = ` with the correct path: 
-
-```sh
-let pkg_config_path = dpdk_path.join("lib/aarch64-linux-gnu/pkgconfig");
-```

--- a/core/build.rs
+++ b/core/build.rs
@@ -15,9 +15,9 @@ fn main() {
 
     let out_dir_s = env::var("OUT_DIR").unwrap();
     let out_dir = Path::new(&out_dir_s);
-    let dpdk_path_s = env::var("DPDK_PATH").unwrap();
-    let dpdk_path = Path::new(&dpdk_path_s);
-    let pkg_config_path = dpdk_path.join("lib/x86_64-linux-gnu/pkgconfig");
+    let load_lib_path_s = env::var("LD_LIBRARY_PATH").unwrap();
+    let load_lib_path = Path::new(&load_lib_path_s);
+    let pkg_config_path = load_lib_path.join("pkgconfig");
     let cflags_bytes = Command::new("pkg-config")
         .env("PKG_CONFIG_PATH", &pkg_config_path)
         .args(["--cflags", "libdpdk"])
@@ -43,7 +43,7 @@ fn main() {
         .stdout;
 
     if ldflags_bytes.is_empty() {
-        println!("Could not get DPDK's LDFLAGS. Is DPDK_PATH set correctly?");
+        println!("Could not get DPDK's LDFLAGS. Are DPDK_PATH, LD_LIBRARY_PATH set correctly?");
         exit(1);
     };
 

--- a/core/src/port/mod.rs
+++ b/core/src/port/mod.rs
@@ -33,14 +33,18 @@ pub(crate) struct PortId(pub(crate) u16);
 impl PortId {
     pub fn new_from_device(device: String) -> PortId {
         let mut port_id: u16 = 0;
-        unsafe {
-            let dev_name = CString::new(device).unwrap();
-            let ret = dpdk::rte_eth_dev_get_port_by_name(dev_name.as_ptr(), &mut port_id);
-            assert_eq!(ret, 0);
+        let _device = device.clone();
+        let ret = 
+            unsafe {
+                let dev_name = CString::new(device).unwrap();
+                dpdk::rte_eth_dev_get_port_by_name(dev_name.as_ptr(), &mut port_id)
+            };
+        if ret != 0 {
+            panic!("Failed to find device by name {}", _device);
         }
 
         if { unsafe { dpdk::rte_eth_dev_is_valid_port(port_id) } } == 0 {
-            panic!("ERROR: Invalid port.");
+            panic!("ERROR: Invalid port ID {}.", port_id);
         }
         PortId(port_id)
     }

--- a/core/src/port/mod.rs
+++ b/core/src/port/mod.rs
@@ -34,11 +34,10 @@ impl PortId {
     pub fn new_from_device(device: String) -> PortId {
         let mut port_id: u16 = 0;
         let _device = device.clone();
-        let ret = 
-            unsafe {
-                let dev_name = CString::new(device).unwrap();
-                dpdk::rte_eth_dev_get_port_by_name(dev_name.as_ptr(), &mut port_id)
-            };
+        let ret = unsafe {
+            let dev_name = CString::new(device).unwrap();
+            dpdk::rte_eth_dev_get_port_by_name(dev_name.as_ptr(), &mut port_id)
+        };
         if ret != 0 {
             panic!("Failed to find device by name {}", _device);
         }


### PR DESCRIPTION
- Troubleshooting bindgen + clang/llvm note
- Use LD_LIBRARY_PATH environment variable in build script to remove need to modify build script for ARM devices
- Throw descriptive error message if port ID is invalid 