### PR TITLE
update parser dependency to stanford-esrg owned versions

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -19,7 +19,7 @@ cpu-time = "1.0.0"
 crossbeam-channel = "0.5.8"
 csv = "1.2.1"
 ctrlc = { version = "3.2.5", features = ["termination"] }
-dns-parser = { git = "https://github.com/thegwan/dns-parser.git" }
+dns-parser = { git = "https://github.com/stanford-esrg/dns-parser" }
 hashlink = "0.7.0"
 hdrhistogram = "7.5.2"
 hex = { version = "0.4.3", features = ["serde"] }
@@ -43,7 +43,7 @@ serde_json = "1.0.96"
 strum = "0.20"
 strum_macros = "0.20"
 thiserror = "1.0"
-tls-parser = { git = "https://github.com/thegwan/tls-parser.git" }
+tls-parser = { git = "https://github.com/stanford-esrg/tls-parser" }
 toml = "0.5.11"
 x509-parser = "0.13.2"
 


### PR DESCRIPTION
Update dependencies for for https://github.com/stanford-esrg/retina/issues/39 