### PR TITLE
Assign RSS offload type with NIC supported values

### DIFF
--- a/core/src/port/mod.rs
+++ b/core/src/port/mod.rs
@@ -295,7 +295,8 @@ impl Port {
             port_conf.rx_adv_conf.rss_conf.rss_key = SYMMETRIC_RSS_KEY.as_ptr() as *mut u8;
             port_conf.rx_adv_conf.rss_conf.rss_key_len = RSS_KEY_LEN as u8;
             port_conf.rx_adv_conf.rss_conf.rss_hf =
-                (dpdk::ETH_RSS_IP | dpdk::ETH_RSS_TCP | dpdk::ETH_RSS_UDP) as u64;
+                (dpdk::ETH_RSS_IP | dpdk::ETH_RSS_TCP | dpdk::ETH_RSS_UDP) as u64
+                    & dev_info.flow_type_rss_offloads;
         }
 
         let max_rx_pkt_len = mtu_to_max_frame_len(mtu as u32);


### PR DESCRIPTION
# Description

As noted in issue https://github.com/stanford-esrg/retina/issues/38, the RSS offload types is currently hardcoded and not all NICs support the set value. This PR takes the suggestion from @tbarbette and updates the assignment to a value provided by the NIC (dev_info.flow_type_rss_offloads).

# Testing

I have only tested this on an Intel X710. If @thearossman can test this on the ConnectX-5 and any other hardware they have that would be great.