### PR TITLE
Move mlx5 feature dependency to example files

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -50,4 +50,4 @@ x509-parser = "0.13.2"
 [features]
 timing = []
 mlx5 = []
-default = ["mlx5"]
+default = []

--- a/examples/basic/Cargo.toml
+++ b/examples/basic/Cargo.toml
@@ -12,6 +12,6 @@ jsonl = "4.0.1"
 lazy_static = "1.4.0"
 log = { version = "0.4", features = ["release_max_level_info"] }
 regex = "1.7.3"
-retina-core = { path = "../../core" }
+retina-core = { path = "../../core", features = ["mlx5"] }
 retina-filtergen = { path = "../../filtergen" }
 serde_json = "1.0.96"

--- a/examples/client_randoms/Cargo.toml
+++ b/examples/client_randoms/Cargo.toml
@@ -10,7 +10,7 @@ clap = { version = "3.2.23", features = ["derive"] }
 env_logger = "0.8.4"
 hex = "0.4.3"
 log = { version = "0.4", features = ["release_max_level_info"] }
-retina-core = { path = "../../core" }
+retina-core = { path = "../../core", features = ["mlx5"] }
 retina-filtergen = { path = "../../filtergen" }
 serde_json = "1.0.96"
 

--- a/examples/ip_anon/Cargo.toml
+++ b/examples/ip_anon/Cargo.toml
@@ -12,7 +12,7 @@ ipcrypt = "0.1.0"
 lazy_static = "1.4.0"
 log = { version = "0.4", features = ["release_max_level_info"] }
 regex = "1.7.3"
-retina-core = { path = "../../core" }
+retina-core = { path = "../../core", features = ["mlx5"] }
 retina-filtergen = { path = "../../filtergen" }
 
 [dependencies.pnet]

--- a/examples/log_conn/Cargo.toml
+++ b/examples/log_conn/Cargo.toml
@@ -12,6 +12,6 @@ jsonl = "4.0.1"
 lazy_static = "1.4.0"
 log = { version = "0.4", features = ["release_max_level_info"] }
 regex = "1.7.3"
-retina-core = { path = "../../core" }
+retina-core = { path = "../../core", features = ["mlx5"] }
 retina-filtergen = { path = "../../filtergen" }
 serde_json = "1.0.96"

--- a/examples/log_dns/Cargo.toml
+++ b/examples/log_dns/Cargo.toml
@@ -12,6 +12,6 @@ jsonl = "4.0.1"
 lazy_static = "1.4.0"
 log = { version = "0.4", features = ["release_max_level_info"] }
 regex = "1.7.3"
-retina-core = { path = "../../core" }
+retina-core = { path = "../../core", features = ["mlx5"] }
 retina-filtergen = { path = "../../filtergen" }
 serde_json = "1.0.96"

--- a/examples/log_http/Cargo.toml
+++ b/examples/log_http/Cargo.toml
@@ -12,6 +12,6 @@ jsonl = "4.0.1"
 lazy_static = "1.4.0"
 log = { version = "0.4", features = ["release_max_level_info"] }
 regex = "1.7.3"
-retina-core = { path = "../../core" }
+retina-core = { path = "../../core", features = ["mlx5"] }
 retina-filtergen = { path = "../../filtergen" }
 serde_json = "1.0.96"

--- a/examples/log_quic/Cargo.toml
+++ b/examples/log_quic/Cargo.toml
@@ -12,6 +12,6 @@ jsonl = "4.0.1"
 lazy_static = "1.4.0"
 log = { version = "0.4", features = ["release_max_level_info"] }
 regex = "1.7.3"
-retina-core = { path = "../../core" }
+retina-core = { path = "../../core", features = ["mlx5"] }
 retina-filtergen = { path = "../../filtergen" }
 serde_json = "1.0.96"

--- a/examples/log_tls/Cargo.toml
+++ b/examples/log_tls/Cargo.toml
@@ -12,6 +12,6 @@ jsonl = "4.0.1"
 lazy_static = "1.4.0"
 log = { version = "0.4", features = ["release_max_level_info"] }
 regex = "1.7.3"
-retina-core = { path = "../../core" }
+retina-core = { path = "../../core", features = ["mlx5"] }
 retina-filtergen = { path = "../../filtergen" }
 serde_json = "1.0.96"

--- a/examples/pcap_dump/Cargo.toml
+++ b/examples/pcap_dump/Cargo.toml
@@ -12,5 +12,5 @@ lazy_static = "1.4.0"
 log = { version = "0.4", features = ["release_max_level_info"] }
 pcap-file = "1.1.1"
 regex = "1.7.3"
-retina-core = { path = "../../core" }
+retina-core = { path = "../../core", features = ["mlx5"] }
 retina-filtergen = { path = "../../filtergen" }

--- a/examples/spin/Cargo.toml
+++ b/examples/spin/Cargo.toml
@@ -9,5 +9,5 @@ anyhow = "1.0.70"
 clap = { version = "3.2.23", features = ["derive"] }
 env_logger = "0.8.4"
 log = { version = "0.4", features = ["release_max_level_info"] }
-retina-core = { path = "../../core" }
+retina-core = { path = "../../core", features = ["mlx5"] }
 retina-filtergen = { path = "../../filtergen" }

--- a/examples/video/Cargo.toml
+++ b/examples/video/Cargo.toml
@@ -13,5 +13,5 @@ hashlink = "0.7.0"
 lazy_static = "1.4.0"
 log = { version = "0.4", features = ["release_max_level_info"] }
 regex = "1.7.3"
-retina-core = { path = "../../core" }
+retina-core = { path = "../../core", features = ["mlx5"] }
 retina-filtergen = { path = "../../filtergen" }


### PR DESCRIPTION
@sippejw kindly tested Retina on Intel E810 and Intel X710 with the changes in #54. At this point, it makes sense to remove mlx5 from default features. I'm keeping it in the examples for now. 