### PR TITLE
Add documentation for onboarding steps

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -162,4 +162,4 @@ When running applications using the provided offline config file, a mempool crea
 ```sh
 Error: Mempool mempool_0 creation failed
 ```
-This can be resolved by reducing the mempool capacity.
+This can be resolved by reducing the mempool capacity in the config file.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -157,3 +157,9 @@ meson setup configure -Dplatform=generic
 export LD_LIBRARY_PATH=$DPDK_PATH/lib/aarch64-linux-gnu
 ```
 
+#### Troubleshooting: Mempool Capacity
+When running applications using the provided offline config file, a mempool creation error may occur:
+```sh
+Error: Mempool mempool_0 creation failed
+```
+This can be resolved by reducing the mempool capacity.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ fn main() {
     runtime.run();
 }
 ```
+Writing a Retina application consists of defining subscriptions. A subscription is defined by (1) [writing a filter](https://stanford-esrg.github.io/retina/retina_filtergen/index.html) to describe what subset of network traffic you're interested in, (2) choosing [data types to subscribe to](https://stanford-esrg.github.io/retina/retina_core/subscription/index.html), and (3) defining a callback function that takes in a subscribable data type and performs operations on the filtered data. 
 
 Build all examples in release mode:
 


### PR DESCRIPTION
1. In INSTALL, document a mempool creation error that may occur when running applications in offline mode using `configs/offline.toml`. Since offline mode is mainly used to test for functionality, this error can be resolved by reducing the mempool capacity in the config file (e.g. setting the capacity to 8192 works).
2. Add more information to README on how users can start writing their own Retina application.

