### PR TITLE
Fixing documentation deployment

### DIFF
--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -60,7 +60,7 @@ jobs:
       run: sudo apt remove --auto-remove clang-14 llvm-14 && sudo apt remove --auto-remove clang-13 llvm-13;
 
     - name: Build Documentation (v0.1.0)
-      run: git checkout v0.1.0 && cargo doc --lib --no-deps
+      run: git fetch --all --tags && git checkout v0.1.0 && cargo doc --lib --no-deps
 
     - name: Move Documentation (v0.1.0)
       run: |


### PR DESCRIPTION
Experimenting with the best way to deploy documentation to gh-pages when we have multiple versions. I don't have a site set up to test locally, so I'm submitting a PR here. 