### PR TITLE
Two documentation changes

### DIFF
--- a/core/src/filter/ptree.rs
+++ b/core/src/filter/ptree.rs
@@ -390,6 +390,16 @@ impl PTree {
                 return;
             }
 
+            if !matches!(self.filter_layer, FilterLayer::PacketContinue) && predicate.req_packet() {
+                // To get similar behavior, users should subscribe to individual mbufs or
+                // the mbuf list, then filter within the callback.
+                // Because (for now) all packets would need to be tracked anyway, doing this
+                // is equivalent performance-wise to implementing similar functionality in the
+                // framework.
+                panic!("Cannot access per-packet fields (e.g., TCP flags, length) after packet filter.\n\
+                       Subscribe to `ZcFrame` or PacketList instead.");
+            }
+
             // Predicate is already present
 
             if node.has_descendant(predicate) {

--- a/datatypes/src/static_type.rs
+++ b/datatypes/src/static_type.rs
@@ -2,11 +2,10 @@
 //! A data type is considered "static" if it can be inferred at or before
 //! the first packet in a connection and it stays constant throughout a connection.
 
-use super::{FromSubscription, StaticData};
+use super::StaticData;
 use pnet::datalink::MacAddr;
 use retina_core::conntrack::conn_id::FiveTuple;
 use retina_core::conntrack::pdu::L4Pdu;
-use retina_core::filter::SubscriptionSpec;
 
 /// Subscribable alias for [`retina_core::FiveTuple`]
 impl StaticData for FiveTuple {
@@ -29,19 +28,6 @@ impl StaticData for EtherTCI {
             }
         }
         EtherTCI(None)
-    }
-}
-
-use proc_macro2::Span;
-use quote::quote;
-
-/// The string literal representing a matched filter.
-pub type FilterStr<'a> = &'a str;
-
-impl<'a> FromSubscription for FilterStr<'a> {
-    fn from_subscription(spec: &SubscriptionSpec) -> proc_macro2::TokenStream {
-        let str = syn::LitStr::new(&spec.filter, Span::call_site());
-        quote! { &#str }
     }
 }
 


### PR DESCRIPTION
- Per-packet fields (e.g., TCP flags, length) can't be accessed after the packet filter

If the user tries to specify this, compilation should fail with a helpful error message.

- PacketList and SessionList were not documented in the previous commit. 