### PR TITLE
Add error for https://github.com/stanford-esrg/retina/issues/66; clean up packet filter generation code

### DIFF
--- a/datatypes/src/conn_fts.rs
+++ b/datatypes/src/conn_fts.rs
@@ -2,7 +2,6 @@
 //! connection information, statistics, and state history.
 
 use crate::Tracked;
-use retina_core::protocols::Session;
 use retina_core::L4Pdu;
 use serde::ser::{Serialize, SerializeSeq, SerializeStruct, Serializer};
 use std::time::{Duration, Instant};
@@ -59,9 +58,6 @@ impl Tracked for ConnDuration {
         }
     }
 
-    #[inline]
-    fn session_matched(&mut self, _session: &Session) {}
-
     fn stream_protocols() -> Vec<&'static str> {
         vec![]
     }
@@ -94,9 +90,6 @@ impl Tracked for PktCount {
         }
     }
 
-    #[inline]
-    fn session_matched(&mut self, _session: &Session) {}
-
     fn stream_protocols() -> Vec<&'static str> {
         vec![]
     }
@@ -128,9 +121,6 @@ impl Tracked for ByteCount {
             self.byte_count += pdu.mbuf_ref().data_len();
         }
     }
-
-    #[inline]
-    fn session_matched(&mut self, _session: &Session) {}
 
     fn stream_protocols() -> Vec<&'static str> {
         vec![]
@@ -190,9 +180,6 @@ impl Tracked for InterArrivals {
             }
         }
     }
-
-    #[inline]
-    fn session_matched(&mut self, _session: &Session) {}
 
     fn stream_protocols() -> Vec<&'static str> {
         vec![]
@@ -267,9 +254,6 @@ impl Tracked for ConnHistory {
             }
         }
     }
-
-    #[inline]
-    fn session_matched(&mut self, _session: &Session) {}
 
     fn stream_protocols() -> Vec<&'static str> {
         vec![]

--- a/datatypes/src/connection.rs
+++ b/datatypes/src/connection.rs
@@ -5,7 +5,6 @@ use retina_core::conntrack::conn::tcp_conn::reassembly::wrapping_lt;
 use retina_core::conntrack::conn_id::FiveTuple;
 use retina_core::conntrack::pdu::L4Pdu;
 use retina_core::protocols::packet::tcp::{ACK, FIN, RST, SYN};
-use retina_core::protocols::stream::Session;
 
 use super::Tracked;
 
@@ -234,8 +233,6 @@ impl Tracked for ConnRecord {
             self.update_data(pdu);
         }
     }
-
-    fn session_matched(&mut self, _session: &Session) {}
 
     fn stream_protocols() -> Vec<&'static str> {
         vec![]

--- a/datatypes/src/typedefs.rs
+++ b/datatypes/src/typedefs.rs
@@ -10,8 +10,8 @@ use std::collections::HashMap;
 use crate::*;
 
 lazy_static! {
-    /// To add a datatype, add it to the following map
-    /// This is read by the filtergen crate.
+    /// To add a datatype, add it to the DATATYPES map
+    /// This is read by the filtergen crate to generate code
     pub static ref DATATYPES: HashMap<&'static str, DataType> = {
         HashMap::from([
             ("ConnRecord", DataType::new_default_connection("ConnRecord")),
@@ -99,13 +99,15 @@ lazy_static! {
     /// session, or packet data. It is simpler to define it as a directly tracked datatype.
     ///
     /// The directly tracked datatypes are: PacketList, SessionList, and CoreId
+    #[doc(hidden)]
     pub static ref DIRECTLY_TRACKED: HashMap<&'static str, &'static str> = HashMap::from([
         ("PacketList", "packets"),
         ("SessionList", "sessions"),
         ("CoreId", "core_id")
     ]);
 
-    // See `FilterStr`
+    /// See `FilterStr`
+    #[doc(hidden)]
     pub static ref FILTER_STR: &'static str = "FilterStr";
 }
 

--- a/filtergen/src/deliver_filter.rs
+++ b/filtergen/src/deliver_filter.rs
@@ -22,11 +22,10 @@ pub(crate) fn gen_deliver_filter(
 
     gen_deliver_util(&mut body, statics, &ptree.root, filter_layer);
     // Ensure root protocol is extracted
-    let body = match filter_layer {
+    match filter_layer {
         FilterLayer::PacketDeliver => PacketDataFilter::add_root_pred(&ptree.root, &body),
         _ => quote! { #( #body )* },
-    };
-    body
+    }
 }
 
 fn gen_deliver_util(
@@ -93,7 +92,7 @@ fn gen_deliver_util(
                             op,
                             value,
                             filter_layer,
-                            &gen_deliver_util
+                            &gen_deliver_util,
                         );
                     } else {
                         ConnDataFilter::add_binary_pred(

--- a/filtergen/src/packet_filter.rs
+++ b/filtergen/src/packet_filter.rs
@@ -16,12 +16,7 @@ pub(crate) fn gen_packet_filter(
         update_body(&mut body, &ptree.root, filter_layer, false);
     }
 
-    gen_packet_filter_util(
-        &mut body,
-        statics,
-        &ptree.root,
-        filter_layer,
-    );
+    gen_packet_filter_util(&mut body, statics, &ptree.root, filter_layer);
 
     let body = PacketDataFilter::add_root_pred(&ptree.root, &body);
 
@@ -51,7 +46,7 @@ fn gen_packet_filter_util(
                     protocol,
                     first_unary,
                     filter_layer,
-                    &gen_packet_filter_util
+                    &gen_packet_filter_util,
                 );
                 first_unary = false;
             }
@@ -70,7 +65,7 @@ fn gen_packet_filter_util(
                     op,
                     value,
                     filter_layer,
-                    &gen_packet_filter_util
+                    &gen_packet_filter_util,
                 );
             }
         }

--- a/filtergen/src/utils.rs
+++ b/filtergen/src/utils.rs
@@ -194,10 +194,10 @@ pub(crate) type BuildChildNodesFn = dyn Fn(
     FilterLayer,
 );
 
-
 pub(crate) struct PacketDataFilter;
 
 impl PacketDataFilter {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn add_unary_pred(
         code: &mut Vec<proc_macro2::TokenStream>,
         statics: &mut Vec<proc_macro2::TokenStream>,
@@ -263,19 +263,20 @@ impl PacketDataFilter {
         }
     }
 
-    pub(crate) fn add_root_pred(root: &PNode, body: &Vec<proc_macro2::TokenStream>) -> proc_macro2::TokenStream {
-
+    pub(crate) fn add_root_pred(
+        root: &PNode,
+        body: &Vec<proc_macro2::TokenStream>,
+    ) -> proc_macro2::TokenStream {
         let name = "ethernet";
         let outer = Ident::new(name, Span::call_site());
         let outer_type = Ident::new(&outer.to_string().to_camel_case(), Span::call_site());
 
-        if !body.is_empty() &&
-             root.children.iter().any(|n| n.pred.on_packet()) {
+        if !body.is_empty() && root.children.iter().any(|n| n.pred.on_packet()) {
             return quote! {
-                    if let Ok(#outer) = &retina_core::protocols::packet::Packet::parse_to::<retina_core::protocols::packet::#outer::#outer_type>(mbuf) {
-                        #( #body )*
-                    }
-                };
+                if let Ok(#outer) = &retina_core::protocols::packet::Packet::parse_to::<retina_core::protocols::packet::#outer::#outer_type>(mbuf) {
+                    #( #body )*
+                }
+            };
         }
         quote! { #( #body )* }
     }


### PR DESCRIPTION
* Document invalid filter (https://github.com/stanford-esrg/retina/issues/66) with error message

* Use `mbufs` where possible at the packet deliver phase when disambiguating between callbacks. This doesn't have a performance impact and may be useful in case we support https://github.com/stanford-esrg/retina/issues/66 in the future.

* Some cleanup to filtergen code: move packet filter codegen to filtergen/utils; remove unused param from gen_pktfilter. 

* This also adds reasonable developer documentation within the `datatypes` crate, which would be needed for anyone adding new datatypes. 