### PR TITLE
Rename SessionState enum to ParsingState

### DIFF
--- a/core/src/conntrack/conn/conn_info.rs
+++ b/core/src/conntrack/conn/conn_info.rs
@@ -9,7 +9,7 @@ use crate::filter::Actions;
 use crate::lcore::CoreId;
 use crate::protocols::packet::tcp::TCP_PROTOCOL;
 use crate::protocols::stream::{
-    ConnData, ParseResult, ParserRegistry, ProbeRegistryResult, ParsingState,
+    ConnData, ParseResult, ParserRegistry, ParsingState, ProbeRegistryResult,
 };
 use crate::subscription::{Subscription, Trackable};
 use crate::FiveTuple;

--- a/core/src/conntrack/conn/conn_info.rs
+++ b/core/src/conntrack/conn/conn_info.rs
@@ -9,7 +9,7 @@ use crate::filter::Actions;
 use crate::lcore::CoreId;
 use crate::protocols::packet::tcp::TCP_PROTOCOL;
 use crate::protocols::stream::{
-    ConnData, ParseResult, ParserRegistry, ProbeRegistryResult, SessionState,
+    ConnData, ParseResult, ParserRegistry, ProbeRegistryResult, ParsingState,
 };
 use crate::subscription::{Subscription, Trackable};
 use crate::FiveTuple;
@@ -163,11 +163,11 @@ where
 
     fn session_done_parse(&mut self, subscription: &Subscription<T::Subscribed>) {
         match self.cdata.conn_parser.session_parsed_state() {
-            SessionState::Probing => {
+            ParsingState::Probing => {
                 // Re-apply the protocol filter to update actions
                 self.actions.session_set_probe();
             }
-            SessionState::Remove => {
+            ParsingState::Stop => {
                 // Done parsing: we expect no more sessions for this connection.
                 self.actions.session_clear_parse();
                 // If the only remaining thing to do is deliver the connection --
@@ -178,7 +178,7 @@ where
                     self.actions.clear();
                 }
             }
-            SessionState::Parsing => {
+            ParsingState::Parsing => {
                 // SessionFilter, Track, and Delivery will be terminal actions if needed.
             }
         }

--- a/core/src/protocols/stream/dns/parser.rs
+++ b/core/src/protocols/stream/dns/parser.rs
@@ -12,7 +12,7 @@ use super::transaction::{DnsQuery, DnsResponse};
 use super::Dns;
 use crate::conntrack::pdu::L4Pdu;
 use crate::protocols::stream::{
-    ConnParsable, ParseResult, ProbeResult, Session, SessionData, ParsingState,
+    ConnParsable, ParseResult, ParsingState, ProbeResult, Session, SessionData,
 };
 
 use std::collections::HashMap;

--- a/core/src/protocols/stream/dns/parser.rs
+++ b/core/src/protocols/stream/dns/parser.rs
@@ -12,7 +12,7 @@ use super::transaction::{DnsQuery, DnsResponse};
 use super::Dns;
 use crate::conntrack::pdu::L4Pdu;
 use crate::protocols::stream::{
-    ConnParsable, ParseResult, ProbeResult, Session, SessionData, SessionState,
+    ConnParsable, ParseResult, ProbeResult, Session, SessionData, ParsingState,
 };
 
 use std::collections::HashMap;
@@ -91,8 +91,8 @@ impl ConnParsable for DnsParser {
             .collect()
     }
 
-    fn session_parsed_state(&self) -> SessionState {
-        SessionState::Parsing
+    fn session_parsed_state(&self) -> ParsingState {
+        ParsingState::Parsing
     }
 }
 

--- a/core/src/protocols/stream/http/parser.rs
+++ b/core/src/protocols/stream/http/parser.rs
@@ -8,7 +8,7 @@ use super::transaction::{HttpRequest, HttpResponse};
 use super::Http;
 use crate::conntrack::pdu::L4Pdu;
 use crate::protocols::stream::{
-    ConnParsable, ParseResult, ProbeResult, Session, SessionData, SessionState,
+    ConnParsable, ParseResult, ProbeResult, Session, SessionData, ParsingState,
 };
 
 use httparse::{Request, EMPTY_HEADER};
@@ -141,7 +141,7 @@ impl ConnParsable for HttpParser {
             .collect()
     }
 
-    fn session_parsed_state(&self) -> SessionState {
-        SessionState::Parsing
+    fn session_parsed_state(&self) -> ParsingState {
+        ParsingState::Parsing
     }
 }

--- a/core/src/protocols/stream/http/parser.rs
+++ b/core/src/protocols/stream/http/parser.rs
@@ -8,7 +8,7 @@ use super::transaction::{HttpRequest, HttpResponse};
 use super::Http;
 use crate::conntrack::pdu::L4Pdu;
 use crate::protocols::stream::{
-    ConnParsable, ParseResult, ProbeResult, Session, SessionData, ParsingState,
+    ConnParsable, ParseResult, ParsingState, ProbeResult, Session, SessionData,
 };
 
 use httparse::{Request, EMPTY_HEADER};

--- a/core/src/protocols/stream/mod.rs
+++ b/core/src/protocols/stream/mod.rs
@@ -129,7 +129,7 @@ pub(crate) trait ConnParsable {
     fn drain_sessions(&mut self) -> Vec<Session>;
 
     /// Indicates whether we expect to see >1 sessions per connection
-    fn session_parsed_state(&self) -> SessionState;
+    fn session_parsed_state(&self) -> ParsingState;
 }
 
 /// Data required to filter on connections.
@@ -310,13 +310,13 @@ impl ConnParser {
         }
     }
 
-    pub(crate) fn session_parsed_state(&self) -> SessionState {
+    pub(crate) fn session_parsed_state(&self) -> ParsingState {
         match self {
             ConnParser::Tls(parser) => parser.session_parsed_state(),
             ConnParser::Dns(parser) => parser.session_parsed_state(),
             ConnParser::Http(parser) => parser.session_parsed_state(),
             ConnParser::Quic(parser) => parser.session_parsed_state(),
-            ConnParser::Unknown => SessionState::Remove,
+            ConnParser::Unknown => ParsingState::Stop,
         }
     }
 
@@ -345,11 +345,11 @@ impl ConnParser {
 }
 
 #[derive(Debug)]
-pub enum SessionState {
+pub enum ParsingState {
     /// Unknown application-layer protocol, needs probing.
     Probing,
     /// Known application-layer protocol, needs parsing.
     Parsing,
     /// No more sessions expected in connection.
-    Remove,
+    Stop,
 }

--- a/core/src/protocols/stream/quic/parser.rs
+++ b/core/src/protocols/stream/quic/parser.rs
@@ -10,7 +10,7 @@ use crate::protocols::stream::quic::header::{
 use crate::protocols::stream::quic::{QuicError, QuicPacket};
 use crate::protocols::stream::tls::Tls;
 use crate::protocols::stream::{
-    ConnParsable, L4Pdu, ParseResult, ProbeResult, Session, SessionData, ParsingState,
+    ConnParsable, L4Pdu, ParseResult, ParsingState, ProbeResult, Session, SessionData,
 };
 use byteorder::{BigEndian, ByteOrder};
 use std::collections::HashSet;

--- a/core/src/protocols/stream/quic/parser.rs
+++ b/core/src/protocols/stream/quic/parser.rs
@@ -10,7 +10,7 @@ use crate::protocols::stream::quic::header::{
 use crate::protocols::stream::quic::{QuicError, QuicPacket};
 use crate::protocols::stream::tls::Tls;
 use crate::protocols::stream::{
-    ConnParsable, L4Pdu, ParseResult, ProbeResult, Session, SessionData, SessionState,
+    ConnParsable, L4Pdu, ParseResult, ProbeResult, Session, SessionData, ParsingState,
 };
 use byteorder::{BigEndian, ByteOrder};
 use std::collections::HashSet;
@@ -109,8 +109,8 @@ impl ConnParsable for QuicParser {
             .collect()
     }
 
-    fn session_parsed_state(&self) -> SessionState {
-        SessionState::Parsing
+    fn session_parsed_state(&self) -> ParsingState {
+        ParsingState::Parsing
     }
 }
 

--- a/core/src/protocols/stream/tls/parser.rs
+++ b/core/src/protocols/stream/tls/parser.rs
@@ -16,7 +16,7 @@ use super::handshake::{
 use super::Tls;
 use crate::conntrack::pdu::L4Pdu;
 use crate::protocols::stream::{
-    ConnParsable, ParseResult, ProbeResult, Session, SessionData, ParsingState,
+    ConnParsable, ParseResult, ParsingState, ProbeResult, Session, SessionData,
 };
 
 use tls_parser::*;

--- a/core/src/protocols/stream/tls/parser.rs
+++ b/core/src/protocols/stream/tls/parser.rs
@@ -16,7 +16,7 @@ use super::handshake::{
 use super::Tls;
 use crate::conntrack::pdu::L4Pdu;
 use crate::protocols::stream::{
-    ConnParsable, ParseResult, ProbeResult, Session, SessionData, SessionState,
+    ConnParsable, ParseResult, ProbeResult, Session, SessionData, ParsingState,
 };
 
 use tls_parser::*;
@@ -92,8 +92,8 @@ impl ConnParsable for TlsParser {
             .collect()
     }
 
-    fn session_parsed_state(&self) -> SessionState {
-        SessionState::Remove
+    fn session_parsed_state(&self) -> ParsingState {
+        ParsingState::Stop
     }
 }
 


### PR DESCRIPTION
1. Rename `SessionState` enum to `ParsingState`
2. Rename enum variant `Remove` to `Stop` 

Updating the enum name provides more clarity on what happens during a connection under multi-subscription Retina. `ParsingState` describes whether we're probing, parsing, or done parsing packets in the connection. However, even after we finish parsing packets, the connection may not terminate. For example, if we specify in our callback that we also want to track packet interarrival times, then we continue updating the interarrival times even after we stop parsing, and the connection terminates only once we finish updating the interarrival times.

