### PR TITLE
Add PacketList Datatypes

### DIFF
--- a/core/src/conntrack/conn/conn_info.rs
+++ b/core/src/conntrack/conn/conn_info.rs
@@ -12,7 +12,7 @@ use crate::protocols::stream::{
     ConnData, ParseResult, ParserRegistry, ParsingState, ProbeRegistryResult,
 };
 use crate::subscription::{Subscription, Trackable};
-use crate::FiveTuple;
+use crate::{FiveTuple, Mbuf};
 
 #[derive(Debug)]
 pub(crate) struct ConnInfo<T>
@@ -77,7 +77,9 @@ where
         }
         if self.actions.buffer_frame() {
             // Track frame for (potential) future delivery
-            self.sdata.track_packet(pdu.mbuf_own());
+            // Used when a filter has partially matched for a
+            // subscription that requests packets
+            self.sdata.track_packet(Mbuf::new_ref(pdu.mbuf_ref()));
         }
     }
 

--- a/core/src/conntrack/mod.rs
+++ b/core/src/conntrack/mod.rs
@@ -138,9 +138,10 @@ where
                     };
                     if let Ok(mut conn) = conn {
                         conn.info.filter_first_packet(&pdu, subscription);
-                        if !conn.info.actions.drop() {
-                            conn.info.consume_pdu(pdu, subscription, &self.registry);
+                        if conn.info.actions.update_pdu() {
+                            conn.info.sdata.update(&pdu, false);
                         }
+                        conn.info.consume_pdu(pdu, subscription, &self.registry);
                         if !conn.remove_from_table() {
                             self.timerwheel.insert(
                                 &conn_id,

--- a/core/src/dpdk/inlined.c
+++ b/core/src/dpdk/inlined.c
@@ -29,6 +29,10 @@ uint16_t rte_mbuf_refcnt_update_(struct rte_mbuf* m, int16_t value) {
     return rte_mbuf_refcnt_update(m, value);
 }
 
+void rte_mbuf_refcnt_set_(struct rte_mbuf* m, int16_t value) {
+    return rte_mbuf_refcnt_set(m, value);
+}
+
 char* rte_pktmbuf_adj_(struct rte_mbuf* m, uint16_t len) {
     return rte_pktmbuf_adj(m, len);
 }

--- a/core/src/dpdk/mod.rs
+++ b/core/src/dpdk/mod.rs
@@ -27,6 +27,7 @@ extern "C" {
     ) -> u16;
     fn rte_mbuf_refcnt_read_(m: *const rte_mbuf) -> u16;
     fn rte_mbuf_refcnt_update_(m: *mut rte_mbuf, value: i16) -> u16;
+    fn rte_mbuf_refcnt_set_(m: *mut rte_mbuf, value: i16);
     fn rte_pktmbuf_adj_(packet: *mut rte_mbuf, len: u16) -> *mut c_char;
     fn rte_pktmbuf_trim_(packet: *mut rte_mbuf, len: u16) -> c_int;
     fn rte_lcore_id_() -> u16;
@@ -103,6 +104,11 @@ pub unsafe fn rte_mbuf_refcnt_read(m: *const rte_mbuf) -> u16 {
 #[inline]
 pub unsafe fn rte_mbuf_refcnt_update(m: *mut rte_mbuf, value: i16) -> u16 {
     rte_mbuf_refcnt_update_(m, value)
+}
+
+#[inline]
+pub unsafe fn rte_mbuf_refcnt_set(m: *mut rte_mbuf, value: i16) {
+    rte_mbuf_refcnt_set_(m, value)
 }
 
 #[inline]

--- a/core/src/filter/ptree.rs
+++ b/core/src/filter/ptree.rs
@@ -397,7 +397,7 @@ impl PTree {
                 // is equivalent performance-wise to implementing similar functionality in the
                 // framework.
                 panic!("Cannot access per-packet fields (e.g., TCP flags, length) after packet filter.\n\
-                       Subscribe to `ZcFrame` or PacketList instead.");
+                       Subscribe to `ZcFrame` or list of mbufs instead.");
             }
 
             // Predicate is already present

--- a/datatypes/src/lib.rs
+++ b/datatypes/src/lib.rs
@@ -30,6 +30,8 @@ pub mod packet;
 pub use packet::{Payload, ZcFrame};
 pub mod static_type;
 pub use static_type::*;
+pub mod packet_list;
+pub use packet_list::*;
 pub use typedefs::*;
 
 use retina_core::conntrack::pdu::L4Pdu;
@@ -91,4 +93,18 @@ pub trait FromSubscription {
     /// Output the literal tokenstream (e.g., string literal) representing
     /// the constant value (e.g., matched filter string).
     fn from_subscription(spec: &SubscriptionSpec) -> proc_macro2::TokenStream;
+}
+
+/// Trait for a datatype that is built from a list of raw packets.
+pub trait PacketList {
+    /// Initialize internal data; called once per connection.
+    /// Note `first_pkt` will also be delivered to `update`.
+    fn new(first_pkt: &L4Pdu) -> Self;
+    /// New packet in connection received (or reassembled, if reassembled=true)
+    /// Note this may be invoked both pre- and post-reassembly; types
+    /// should check `reassembled` to avoid double-counting.
+    fn update(&mut self, pdu: &L4Pdu, reassembled: bool);
+    /// Clear internal data; called if connection no longer matches filter
+    /// that requires the Tracked type.
+    fn clear(&mut self);
 }

--- a/datatypes/src/packet_list.rs
+++ b/datatypes/src/packet_list.rs
@@ -1,0 +1,428 @@
+//! Vectors of raw packet data.
+//! All of these types are Connection-level, meaning they are delivered on
+//! connection termination.
+//!
+//! There are two types of packet lists: those containing Mbufs (`Zc` prefix)
+//! and those containing raw bytes (as vectors).
+//!
+//! For the former: Mbufs are shared across these lists via DPDK reference counting,
+//! so requesting lists of packets does not require copying. However, it may
+//! introduce additional mempool requirements, as Mbufs must be kept in memory
+//! for the duration of the connection. This is often particularly infeasible for
+//! UDP connections, which must stay in memory until a timeout is reached.
+//! In such cases, users may wish to use the non-`Zc` variants.
+//!
+//! For TCP connections, the non-`Zc` variants wait to clone data until the
+//! first few packets have passed or until the packet data is requested.
+//! After the first `PKTS_START_CLONE` packets, it is likely that some traffic has
+//! been filtered out by the framework (e.g., TLS handshake has been parsed).
+//! This is a middle ground between memory usage and compute performance.
+//!
+//! For UDP connections, this is not feasible without unacceptable mempool utilization;
+//! many UDP connections are short-lived, and UDP connections are not "closed" until
+//! a timeout period has passed.
+
+use crate::PacketList;
+use retina_core::{protocols::packet::tcp::TCP_PROTOCOL, L4Pdu, Mbuf};
+
+/// Pasic raw packet bytes.
+#[derive(Debug)]
+pub struct PktData {
+    pub data: Vec<u8>,
+}
+
+impl PktData {
+    pub fn new(mbuf: &Mbuf) -> Self {
+        Self {
+            data: mbuf.data().to_vec(),
+        }
+    }
+}
+
+/// Number of Mbufs to cache before starting to clone data for
+/// TCP connections only. If PKTS_START_CLONE is not reached, the
+/// data is converted to Vec<u8> on first access.
+const PKTS_START_CLONE: usize = 5;
+
+pub trait PktStream {
+    fn in_mbufs_own(&mut self) -> Vec<Mbuf>;
+    fn in_mbufs_ref(&mut self) -> &mut Vec<Mbuf>;
+    fn out_packets(&mut self) -> &mut Vec<PktData>;
+
+    fn drain_mbufs(&mut self) {
+        let mut in_mbufs = self.in_mbufs_own();
+        for mbuf in in_mbufs.drain(..) {
+            self.out_packets().push(PktData::new(&mbuf));
+        }
+    }
+
+    fn packets(&mut self) -> &Vec<PktData> {
+        if self.in_mbufs_ref().is_empty() {
+            return self.out_packets();
+        }
+        self.drain_mbufs();
+        self.out_packets()
+    }
+
+    fn push(&mut self, pdu: &L4Pdu) {
+        if pdu.ctxt.proto == TCP_PROTOCOL && self.in_mbufs_ref().len() < PKTS_START_CLONE {
+            self.in_mbufs_ref().push(Mbuf::new_ref(&pdu.mbuf));
+            return;
+        } else if !self.in_mbufs_ref().is_empty() {
+            self.drain_mbufs();
+        }
+        self.out_packets().push(PktData::new(pdu.mbuf_ref()));
+    }
+}
+
+/// For a connection, the bidirectional stream of packets
+/// in the order received by the framework.
+#[derive(Debug)]
+pub struct BidirPktStream {
+    /// The raw packet data.
+    pub packets: Vec<PktData>,
+    /// The first few packets are stored as Mbufs
+    /// before data copies begin.
+    mbufs: Vec<Mbuf>,
+}
+
+impl PktStream for BidirPktStream {
+    fn in_mbufs_own(&mut self) -> Vec<Mbuf> {
+        std::mem::take(&mut self.mbufs)
+    }
+
+    fn in_mbufs_ref(&mut self) -> &mut Vec<Mbuf> {
+        &mut self.mbufs
+    }
+
+    fn out_packets(&mut self) -> &mut Vec<PktData> {
+        &mut self.packets
+    }
+}
+
+impl PacketList for BidirPktStream {
+    fn new(_first_pkt: &L4Pdu) -> Self {
+        Self {
+            packets: Vec::new(),
+            mbufs: Vec::new(),
+        }
+    }
+
+    fn update(&mut self, pdu: &L4Pdu, reassembled: bool) {
+        if !reassembled {
+            self.push(pdu);
+        }
+    }
+
+    fn clear(&mut self) {
+        self.packets.clear();
+        self.mbufs.clear();
+    }
+}
+
+/// For a connection, an originator's (unidirectional) stream of packets
+/// in the order received by the framework. For TCP streams, the
+/// "originator" is the endpoint that sends the first SYN. For UDP,
+/// it is the endpoint which sends the first-seen packet.
+pub struct OrigPktStream {
+    /// The raw packet data.
+    pub packets: Vec<PktData>,
+    /// The first few packets are stored as Mbufs
+    /// before data copies begin.
+    mbufs: Vec<Mbuf>,
+}
+
+impl PktStream for OrigPktStream {
+    fn in_mbufs_own(&mut self) -> Vec<Mbuf> {
+        std::mem::take(&mut self.mbufs)
+    }
+
+    fn in_mbufs_ref(&mut self) -> &mut Vec<Mbuf> {
+        &mut self.mbufs
+    }
+
+    fn out_packets(&mut self) -> &mut Vec<PktData> {
+        &mut self.packets
+    }
+}
+
+impl PacketList for OrigPktStream {
+    fn new(_first_pkt: &L4Pdu) -> Self {
+        Self {
+            packets: Vec::new(),
+            mbufs: Vec::new(),
+        }
+    }
+
+    fn update(&mut self, pdu: &L4Pdu, reassembled: bool) {
+        if pdu.dir && !reassembled {
+            self.push(pdu);
+        }
+    }
+
+    fn clear(&mut self) {
+        self.packets.clear();
+        self.mbufs.clear();
+    }
+}
+
+/// For a connection, a responder's (unidirectional) stream of packets
+/// in the order received by the framework. For TCP streams, the
+/// "responder" is the endpoint that receives the first SYN and responds
+/// with a SYN/ACK. For UDP, it is the endpoint which does not send the
+/// first packet.
+pub struct RespPktStream {
+    /// The raw packet data.
+    pub packets: Vec<PktData>,
+    /// The first few packets are stored as Mbufs
+    /// before data copies begin.
+    mbufs: Vec<Mbuf>,
+}
+
+impl PktStream for RespPktStream {
+    fn in_mbufs_own(&mut self) -> Vec<Mbuf> {
+        std::mem::take(&mut self.mbufs)
+    }
+
+    fn in_mbufs_ref(&mut self) -> &mut Vec<Mbuf> {
+        &mut self.mbufs
+    }
+
+    fn out_packets(&mut self) -> &mut Vec<PktData> {
+        &mut self.packets
+    }
+}
+
+impl PacketList for RespPktStream {
+    fn new(_first_pkt: &L4Pdu) -> Self {
+        Self {
+            packets: Vec::new(),
+            mbufs: Vec::new(),
+        }
+    }
+
+    fn update(&mut self, pdu: &L4Pdu, reassembled: bool) {
+        if !pdu.dir && !reassembled {
+            self.push(pdu);
+        }
+    }
+
+    fn clear(&mut self) {
+        self.packets.clear();
+        self.mbufs.clear();
+    }
+}
+
+/// For a connection, an originator's (unidirectional) stream of packets
+/// in reassembled order. This should be used for TCP only.
+pub struct OrigPktsReassembled {
+    /// The raw packet data.
+    pub packets: Vec<PktData>,
+    /// The first few packets are stored as Mbufs
+    /// before data copies begin.
+    mbufs: Vec<Mbuf>,
+}
+
+impl PktStream for OrigPktsReassembled {
+    fn in_mbufs_own(&mut self) -> Vec<Mbuf> {
+        std::mem::take(&mut self.mbufs)
+    }
+
+    fn in_mbufs_ref(&mut self) -> &mut Vec<Mbuf> {
+        &mut self.mbufs
+    }
+
+    fn out_packets(&mut self) -> &mut Vec<PktData> {
+        &mut self.packets
+    }
+}
+
+impl PacketList for OrigPktsReassembled {
+    fn new(_first_pkt: &L4Pdu) -> Self {
+        Self {
+            packets: Vec::new(),
+            mbufs: Vec::new(),
+        }
+    }
+
+    fn update(&mut self, pdu: &L4Pdu, reassembled: bool) {
+        if pdu.dir && reassembled {
+            self.push(pdu);
+        }
+    }
+
+    fn clear(&mut self) {
+        self.packets.clear();
+        self.mbufs.clear();
+    }
+}
+
+/// For a connection, a responder's (unidirectional) stream of packets
+/// in reassembled order. This should be used for TCP only.
+pub struct RespPktsReassembled {
+    /// The raw packet data.
+    pub packets: Vec<PktData>,
+    /// The first few packets are stored as Mbufs
+    /// before data copies begin.
+    mbufs: Vec<Mbuf>,
+}
+
+impl PktStream for RespPktsReassembled {
+    fn in_mbufs_own(&mut self) -> Vec<Mbuf> {
+        std::mem::take(&mut self.mbufs)
+    }
+
+    fn in_mbufs_ref(&mut self) -> &mut Vec<Mbuf> {
+        &mut self.mbufs
+    }
+
+    fn out_packets(&mut self) -> &mut Vec<PktData> {
+        &mut self.packets
+    }
+}
+
+impl PacketList for RespPktsReassembled {
+    fn new(_first_pkt: &L4Pdu) -> Self {
+        Self {
+            packets: Vec::new(),
+            mbufs: Vec::new(),
+        }
+    }
+
+    fn update(&mut self, pdu: &L4Pdu, reassembled: bool) {
+        if !pdu.dir && reassembled {
+            self.push(pdu);
+        }
+    }
+
+    fn clear(&mut self) {
+        self.packets.clear();
+        self.mbufs.clear();
+    }
+}
+
+/// For a connection, the bidirectional stream of packets
+/// in the order received by the framework.
+pub struct BidirZcPktStream {
+    pub packets: Vec<Mbuf>,
+}
+
+impl PacketList for BidirZcPktStream {
+    fn new(_first_pkt: &L4Pdu) -> Self {
+        Self {
+            packets: Vec::new(),
+        }
+    }
+
+    fn update(&mut self, pdu: &L4Pdu, reassembled: bool) {
+        if !reassembled {
+            self.packets.push(Mbuf::new_ref(&pdu.mbuf));
+        }
+    }
+
+    fn clear(&mut self) {
+        self.packets.clear();
+    }
+}
+
+/// For a connection, an originator's (unidirectional) stream of packets
+/// in the order received by the framework. For TCP streams, the
+/// "originator" is the endpoint that sends the first SYN. For UDP,
+/// it is the endpoint which sends the first-seen packet.
+pub struct OrigZcPktStream {
+    pub packets: Vec<Mbuf>,
+}
+
+impl PacketList for OrigZcPktStream {
+    fn new(_first_pkt: &L4Pdu) -> Self {
+        Self {
+            packets: Vec::new(),
+        }
+    }
+
+    fn update(&mut self, pdu: &L4Pdu, reassembled: bool) {
+        if !reassembled && pdu.dir {
+            self.packets.push(Mbuf::new_ref(&pdu.mbuf));
+        }
+    }
+
+    fn clear(&mut self) {
+        self.packets.clear();
+    }
+}
+
+/// For a connection, a responder's (unidirectional) stream of packets
+/// in the order received by the framework. For TCP streams, the
+/// "responder" is the endpoint that receives the first SYN and responds
+/// with a SYN/ACK. For UDP, it is the endpoint which does not send the
+/// first packet.
+pub struct RespZcPktStream {
+    pub packets: Vec<Mbuf>,
+}
+
+impl PacketList for RespZcPktStream {
+    fn new(_first_pkt: &L4Pdu) -> Self {
+        // TODO figure out good default capacity
+        Self {
+            packets: Vec::new(),
+        }
+    }
+
+    fn update(&mut self, pdu: &L4Pdu, reassembled: bool) {
+        if !reassembled && !pdu.dir {
+            self.packets.push(Mbuf::new_ref(&pdu.mbuf));
+        }
+    }
+
+    fn clear(&mut self) {
+        self.packets.clear();
+    }
+}
+
+/// For a connection, an originator's (unidirectional) stream of packets
+/// in reassembled order. This should be used for TCP only.
+pub struct OrigZcPktsReassembled {
+    pub packets: Vec<Mbuf>,
+}
+
+impl PacketList for OrigZcPktsReassembled {
+    fn new(_first_pkt: &L4Pdu) -> Self {
+        Self {
+            packets: Vec::new(),
+        }
+    }
+
+    fn update(&mut self, pdu: &L4Pdu, reassembled: bool) {
+        if reassembled && pdu.dir {
+            self.packets.push(Mbuf::new_ref(&pdu.mbuf));
+        }
+    }
+
+    fn clear(&mut self) {
+        self.packets.clear();
+    }
+}
+
+/// For a connection, a responder's (unidirectional) stream of packets
+/// in reassembled order. This should be used for TCP only.
+pub struct RespZcPktsReassembled {
+    pub packets: Vec<Mbuf>,
+}
+
+impl PacketList for RespZcPktsReassembled {
+    fn new(_first_pkt: &L4Pdu) -> Self {
+        Self {
+            packets: Vec::new(),
+        }
+    }
+
+    fn update(&mut self, pdu: &L4Pdu, reassembled: bool) {
+        if reassembled && !pdu.dir {
+            self.packets.push(Mbuf::new_ref(&pdu.mbuf));
+        }
+    }
+
+    fn clear(&mut self) {
+        self.packets.clear();
+    }
+}

--- a/datatypes/src/typedefs.rs
+++ b/datatypes/src/typedefs.rs
@@ -50,18 +50,6 @@ lazy_static! {
             ),
             ("ZcFrame", DataType::new_default_packet("ZcFrame")),
             ("Payload", DataType::new_default_packet("Payload")),
-            ("PacketList", {
-                DataType {
-                    level: Level::Connection,
-                    needs_parse: false,
-                    track_sessions: false,
-                    needs_update: false,
-                    needs_update_reassembled: false,
-                    track_packets: true,
-                    stream_protos: vec![],
-                    as_str: "PacketList",
-                }
-            }),
             ("SessionList", {
                 DataType {
                     level: Level::Connection,
@@ -69,11 +57,20 @@ lazy_static! {
                     track_sessions: true,
                     needs_update: false,
                     needs_update_reassembled: false,
-                    track_packets: false,
                     stream_protos: vec!["tls", "dns", "http", "quic"],
                     as_str: "SessionList",
                 }
             }),
+            ("BidirZcPktStream", { DataType::new_default_pktlist("BidirZcPktStream", false) }),
+            ("OrigZcPktStream", { DataType::new_default_pktlist("OrigZcPktStream", false) }),
+            ("RespZcPktStream", { DataType::new_default_pktlist("RespZcPktStream", false) }),
+            ("OrigZcPktsReassembled", { DataType::new_default_pktlist("OrigZcPktsReassembled", true) }),
+            ("RespZcPktsReassembled", { DataType::new_default_pktlist("RespZcPktsReassembled", true) }),
+            ("BidirPktStream", { DataType::new_default_pktlist("BidirPktStream", false) }),
+            ("OrigPktStream", { DataType::new_default_pktlist("OrigPktStream", false) }),
+            ("RespPktStream", { DataType::new_default_pktlist("RespPktStream", false) }),
+            ("OrigPktsReassembled", { DataType::new_default_pktlist("OrigPktsReassembled", true) }),
+            ("RespPktsReassembled", { DataType::new_default_pktlist("RespPktsReassembled", true) }),
             ("CoreId", { DataType::new_default_static("CoreId") }),
             ("FiveTuple", { DataType::new_default_static("FiveTuple") }),
             ("EtherTCI", { DataType::new_default_static("EtherTCI") }),
@@ -101,7 +98,6 @@ lazy_static! {
     /// The directly tracked datatypes are: PacketList, SessionList, and CoreId
     #[doc(hidden)]
     pub static ref DIRECTLY_TRACKED: HashMap<&'static str, &'static str> = HashMap::from([
-        ("PacketList", "packets"),
         ("SessionList", "sessions"),
         ("CoreId", "core_id")
     ]);
@@ -111,9 +107,6 @@ lazy_static! {
     pub static ref FILTER_STR: &'static str = "FilterStr";
 }
 
-/// A list of all packets (zero-copy) seen in the connection.
-/// For TCP connections, these packets will be in post-reassembly order.
-pub type PacketList = Vec<Mbuf>;
 /// A list of all sessions (zero-copy) parsed in the connection.
 pub type SessionList = Vec<Session>;
 

--- a/filtergen/src/lib.rs
+++ b/filtergen/src/lib.rs
@@ -296,7 +296,7 @@ fn generate(input: syn::ItemFn, config: SubscriptionConfig) -> TokenStream {
         use retina_core::filter::actions::*;
         // Import potentially-needed traits
         use retina_core::subscription::{Trackable, Subscribable};
-        use retina_datatypes::{FromSession, Tracked, FromMbuf, StaticData};
+        use retina_datatypes::{FromSession, Tracked, FromMbuf, StaticData, PacketList};
 
         #subscribable
 


### PR DESCRIPTION
Create multiple, user-defined datatypes for caching Mbufs (raw packets) for end of connection delivery.

This also adds infrastructure for sharing Mbufs using DPDK's reference counting infrastructure (see memory/mbuf file). This gives us a way to share Mbufs between multiple data structures (e.g., pre- and post-reassembly) without copying and with lower overhead than Rust's Rc or Arc infrastructure. It may encounter issues if Mbufs are shared across threads, but they will not be in the current architecture. This infrastructure is critical for supporting future streaming datatypes.

Note that, with some of these datatypes, mempool availability can become the bottleneck, especially when working with UDP connections (which cannot be delivered until timeout). In some cases, it is more efficient to copy Mbufs into byte arrays.

Testing done: wrote examples for offline mode; printed out raw bytes (hex) in packet lists and compared to wireshark raw bytes. 