### PR TITLE
Minor TCP Reassembly and Packet Tracking Changes

### DIFF
--- a/core/src/conntrack/conn/conn_info.rs
+++ b/core/src/conntrack/conn/conn_info.rs
@@ -50,12 +50,15 @@ where
     }
 
     #[inline]
-    pub(crate) fn update_sdata(&mut self, pdu: &L4Pdu,
-                               subscription: &Subscription<T::Subscribed>,
-                               reassembled: bool) {
+    pub(crate) fn update_sdata(
+        &mut self,
+        pdu: &L4Pdu,
+        subscription: &Subscription<T::Subscribed>,
+        reassembled: bool,
+    ) {
         // Typically use for calculating connection metrics
         if self.actions.update_pdu() {
-            self.sdata.update(&pdu, reassembled);
+            self.sdata.update(pdu, reassembled);
         }
         // Used for non-terminal matches on packet datatypes (`PacketCache` action,
         // pre-reassembly only) and for datatypes that require tracking packets
@@ -67,8 +70,7 @@ where
         // delivered 1x (before reassembly).
         if !reassembled && self.actions.packet_deliver() {
             // Delivering all remaining packets in connection
-            subscription.deliver_packet(pdu.mbuf_ref(),
-                                    &self.cdata, &self.sdata);
+            subscription.deliver_packet(pdu.mbuf_ref(), &self.cdata, &self.sdata);
         }
     }
 

--- a/core/src/conntrack/conn/tcp_conn/mod.rs
+++ b/core/src/conntrack/conn/tcp_conn/mod.rs
@@ -45,12 +45,10 @@ impl TcpConn {
     #[inline]
     pub(crate) fn is_terminated(&self) -> bool {
         // Both sides have sent, reassembled, and acknowledged FIN, or RST has been sent
-        (self.ctos.consumed_flags & self.stoc.consumed_flags & FIN != 0 &&
-         self.ctos.last_ack == self.stoc.next_seq &&
-         self.stoc.last_ack == self.ctos.next_seq) ||
-        (self.ctos.consumed_flags & RST
-            | self.stoc.consumed_flags & RST)
-            != 0
+        (self.ctos.consumed_flags & self.stoc.consumed_flags & FIN != 0
+            && self.ctos.last_ack == self.stoc.next_seq
+            && self.stoc.last_ack == self.ctos.next_seq)
+            || (self.ctos.consumed_flags & RST | self.stoc.consumed_flags & RST) != 0
     }
 
     /// Updates connection termination flags

--- a/core/src/conntrack/mod.rs
+++ b/core/src/conntrack/mod.rs
@@ -100,12 +100,12 @@ where
                     return;
                 }
                 let pdu = L4Pdu::new(mbuf, ctxt, dir);
-                if conn.info.actions.update_pdu() {
-                    conn.info.sdata.update(&pdu, false);
-                }
-                if conn.info.actions.update_conn() {
+                conn.info.update_sdata(&pdu, subscription, false);
+                // Consume PDU for reassembly or parsing
+                if conn.info.actions.reassemble() {
                     conn.update(pdu, subscription, &self.registry);
                 } else {
+                    // Ensure FIN is handled, if appl.
                     conn.update_tcp_flags(pdu.flags(), pdu.dir);
                 }
 
@@ -138,10 +138,10 @@ where
                     };
                     if let Ok(mut conn) = conn {
                         conn.info.filter_first_packet(&pdu, subscription);
-                        if conn.info.actions.update_pdu() {
-                            conn.info.sdata.update(&pdu, false);
+                        conn.info.update_sdata(&pdu, subscription, false);
+                        if conn.info.actions.reassemble() {
+                            conn.info.consume_pdu(pdu, subscription, &self.registry);
                         }
-                        conn.info.consume_pdu(pdu, subscription, &self.registry);
                         if !conn.remove_from_table() {
                             self.timerwheel.insert(
                                 &conn_id,

--- a/core/src/conntrack/pdu.rs
+++ b/core/src/conntrack/pdu.rs
@@ -52,6 +52,11 @@ impl L4Pdu {
     }
 
     #[inline]
+    pub fn ack_no(&self) -> u32 {
+        self.ctxt.ack_no
+    }
+
+    #[inline]
     pub fn flags(&self) -> u8 {
         self.ctxt.flags
     }
@@ -72,6 +77,8 @@ pub struct L4Context {
     pub length: usize,
     /// Raw sequence number of segment.
     pub seq_no: u32,
+    /// Raw acknowledgment number of segment.
+    pub ack_no: u32,
     /// TCP flags.
     pub flags: u8,
 }
@@ -91,6 +98,7 @@ impl L4Context {
                             offset: tcp.next_header_offset(),
                             length: payload_size,
                             seq_no: tcp.seq_no(),
+                            ack_no: tcp.ack_no(),
                             flags: tcp.flags(),
                         })
                     } else {
@@ -107,6 +115,7 @@ impl L4Context {
                             offset: udp.next_header_offset(),
                             length: payload_size,
                             seq_no: 0,
+                            ack_no: 0,
                             flags: 0,
                         })
                     } else {
@@ -127,6 +136,7 @@ impl L4Context {
                             offset: tcp.next_header_offset(),
                             length: payload_size,
                             seq_no: tcp.seq_no(),
+                            ack_no: tcp.ack_no(),
                             flags: tcp.flags(),
                         })
                     } else {
@@ -143,6 +153,7 @@ impl L4Context {
                             offset: udp.next_header_offset(),
                             length: payload_size,
                             seq_no: 0,
+                            ack_no: 0,
                             flags: 0,
                         })
                     } else {

--- a/core/src/filter/actions.rs
+++ b/core/src/filter/actions.rs
@@ -137,9 +137,10 @@ impl Actions {
     pub(crate) fn buffer_packet(&self, reassembled: bool) -> bool {
         match reassembled {
             true => self.data.intersects(ActionData::PacketTrack),
-            false => self.data.intersects(ActionData::PacketTrack | ActionData::PacketCache)
+            false => self
+                .data
+                .intersects(ActionData::PacketTrack | ActionData::PacketCache),
         }
-
     }
 
     #[inline]

--- a/core/src/filter/actions.rs
+++ b/core/src/filter/actions.rs
@@ -28,8 +28,12 @@ pub enum ActionData {
     /// - All other filters: post-reassembly
     PacketDeliver,
 
-    /// Store future packets in this connection in tracked data
-    /// TCP packets are tracked post-reassembly
+    /// Store packets in this connection in tracked data for
+    /// potential future delivery. Used on a non-terminal match
+    /// for a packet-level datatype.
+    PacketCache,
+    /// Store packets in this connection in tracked data for a
+    /// datatype that requires tracking and delivering packets.
     PacketTrack,
 
     // Connection/session actions //
@@ -48,8 +52,9 @@ pub enum ActionData {
 
     /// The subscribable type "update" methods should be invoked (for TCP: pre-reassembly)
     UpdatePDU,
+
     /// The subscribable type "update" methods should be invoked post-reassembly (TCP only)
-    ReassembledUpdatePDU,
+    Reassemble,
 
     /// Deliver connection data (via the ConnectionDelivery filter) when it terminates
     ConnDeliver,
@@ -120,15 +125,26 @@ impl Actions {
         self.data.intersects(ActionData::UpdatePDU)
     }
 
-    /// Conn tracker must deliver PDU to tracked data after reassembly
-    pub(crate) fn update_pdu_reassembled(&self) -> bool {
-        self.data.intersects(ActionData::ReassembledUpdatePDU)
+    /// True if the connection needs to be reassembled
+    pub(crate) fn reassemble(&self) -> bool {
+        self.data.intersects(ActionData::Reassemble) || self.parse_any()
     }
 
-    /// True if the framework should track (buffer) mbufs for this connection
+    /// True if the framework should buffer mbufs for this connection,
+    /// either for future delivery (Cache) or for a datatype that requires
+    /// tracking packets.
     #[inline]
-    pub(crate) fn buffer_frame(&self) -> bool {
-        self.data.intersects(ActionData::PacketTrack)
+    pub(crate) fn buffer_packet(&self, reassembled: bool) -> bool {
+        match reassembled {
+            true => self.data.intersects(ActionData::PacketTrack),
+            false => self.data.intersects(ActionData::PacketTrack | ActionData::PacketCache)
+        }
+
+    }
+
+    #[inline]
+    pub(crate) fn cache_packet(&self) -> bool {
+        self.data.intersects(ActionData::PacketCache)
     }
 
     /// True if application-layer probing or parsing should be applied
@@ -141,16 +157,6 @@ impl Actions {
                 | ActionData::SessionDeliver
                 | ActionData::SessionTrack,
         )
-    }
-
-    /// True if the framework should consume PDUs for reassembly (TCP),
-    /// parsing, or operations that require ownership of packets.
-    #[inline]
-    pub(crate) fn update_conn(&self) -> bool {
-        self.parse_any()
-            || self.update_pdu_reassembled()
-            || self.buffer_frame()
-            || self.packet_deliver()
     }
 
     /// True if nothing except delivery is required
@@ -293,8 +299,9 @@ impl FromStr for ActionData {
             "SessionDeliver" => Ok(ActionData::SessionDeliver),
             "SessionTrack" => Ok(ActionData::SessionTrack),
             "UpdatePDU" => Ok(ActionData::UpdatePDU),
-            "ReassembledUpdatePDU" => Ok(ActionData::ReassembledUpdatePDU),
+            "Reassemble" => Ok(ActionData::Reassemble),
             "PacketTrack" => Ok(ActionData::PacketTrack),
+            "PacketCache" => Ok(ActionData::PacketCache),
             "ConnDeliver" => Ok(ActionData::ConnDeliver),
             _ => Result::Err(core::fmt::Error),
         }
@@ -312,8 +319,9 @@ impl fmt::Display for ActionData {
             ActionData::SessionDeliver => "SessionDeliver",
             ActionData::SessionTrack => "SessionTrack",
             ActionData::UpdatePDU => "UpdatePDU",
-            ActionData::ReassembledUpdatePDU => "ReassembledUpdatePDU",
+            ActionData::Reassemble => "Reassemble",
             ActionData::PacketTrack => "PacketTrack",
+            ActionData::PacketCache => "PacketCache",
             ActionData::ConnDeliver => "ConnDeliver",
             _ => panic!("Unknown ActionData"),
         };

--- a/core/src/filter/datatypes.rs
+++ b/core/src/filter/datatypes.rs
@@ -55,8 +55,10 @@ pub struct DataType {
     pub track_sessions: bool,
     /// True if the datatype requires invoking `update` method before reassembly
     pub needs_update: bool,
-    /// True if the datatype requires invoking `update` method after reassembly
-    pub needs_update_reassembled: bool,
+    /// True if the datatype requires reassembly (for `track_packets` or `update`)
+    pub needs_reassembly: bool,
+    /// True if the datatype requires tracking packets
+    pub needs_packet_track: bool,
     /// A vector of the application-layer parsers required by this datatype
     /// Retina loads the union of parsers required by all datatypes and filters
     pub stream_protos: Vec<&'static str>,
@@ -73,7 +75,8 @@ impl DataType {
             needs_parse: false,
             track_sessions: false,
             needs_update: true,
-            needs_update_reassembled: false,
+            needs_reassembly: false,
+            needs_packet_track: false,
             stream_protos: vec![],
             as_str,
         }
@@ -87,7 +90,8 @@ impl DataType {
             needs_parse: true,
             track_sessions: false,
             needs_update: false,
-            needs_update_reassembled: false,
+            needs_reassembly: false,
+            needs_packet_track: false,
             stream_protos,
             as_str,
         }
@@ -101,7 +105,8 @@ impl DataType {
             needs_parse: false,
             track_sessions: false,
             needs_update: false,
-            needs_update_reassembled: false,
+            needs_reassembly: false,
+            needs_packet_track: false,
             stream_protos: vec![],
             as_str,
         }
@@ -115,19 +120,21 @@ impl DataType {
             needs_parse: false,
             track_sessions: false,
             needs_update: false,
-            needs_update_reassembled: false,
+            needs_reassembly: false,
+            needs_packet_track: false,
             stream_protos: vec![],
             as_str,
         }
     }
 
-    pub fn new_default_pktlist(as_str: &'static str, reassembly: bool) -> Self {
+    pub fn new_default_pktlist(as_str: &'static str, needs_reassembly: bool) -> Self {
         DataType {
             level: Level::Connection,
             needs_parse: false,
             track_sessions: false,
-            needs_update: !reassembly,
-            needs_update_reassembled: reassembly,
+            needs_update: false,
+            needs_reassembly,
+            needs_packet_track: true,
             stream_protos: vec![],
             as_str,
         }
@@ -207,10 +214,15 @@ impl DataType {
             actions.if_matched.terminal_actions |= ActionData::UpdatePDU;
             actions.if_matching.data |= ActionData::UpdatePDU;
         }
-        if self.needs_update_reassembled {
-            actions.if_matched.data |= ActionData::ReassembledUpdatePDU;
-            actions.if_matched.terminal_actions |= ActionData::ReassembledUpdatePDU;
-            actions.if_matching.data |= ActionData::ReassembledUpdatePDU;
+        if self.needs_reassembly {
+            actions.if_matched.data |= ActionData::Reassemble;
+            actions.if_matched.terminal_actions |= ActionData::Reassemble;
+            actions.if_matching.data |= ActionData::Reassemble;
+        }
+        if self.needs_packet_track {
+            actions.if_matched.data |= ActionData::PacketTrack;
+            actions.if_matched.terminal_actions |= ActionData::PacketTrack;
+            actions.if_matching.data |= ActionData::PacketTrack;
         }
     }
 
@@ -242,7 +254,7 @@ impl DataType {
         // and (2) tracked until then.
         if matches!(self.level, Level::Packet) {
             assert!(matches!(sub_level, Level::Packet));
-            actions.if_matching.data |= ActionData::PacketTrack;
+            actions.if_matching.data |= ActionData::PacketCache;
             // Matched packet-level subscription is delivered in filter
         }
 
@@ -283,7 +295,7 @@ impl DataType {
             actions.if_matched.data |= ActionData::PacketDeliver;
             actions.if_matched.terminal_actions |= ActionData::PacketDeliver;
             // Track in case of match in next filter
-            actions.if_matching.data |= ActionData::PacketTrack;
+            actions.if_matching.data |= ActionData::PacketCache;
         }
 
         // Connection- and session-level subscriptions depend on the actions required
@@ -591,6 +603,6 @@ mod tests {
         let mut spec = SubscriptionSpec::new(String::from(""), String::from("cb"));
         spec.add_datatype(DataType::new_default_packet("Packet"));
         assert!(spec.proto_filter().if_matched.packet_deliver());
-        assert!(spec.proto_filter().if_matching.buffer_frame());
+        assert!(spec.proto_filter().if_matching.cache_packet());
     }
 }

--- a/core/src/filter/ptree.rs
+++ b/core/src/filter/ptree.rs
@@ -982,7 +982,7 @@ mod tests {
         // Remaining: eth -> tcp, udp
         assert!(ptree.size == 4);
         expected_actions.clear();
-        expected_actions.data = ActionData::ProtoFilter | ActionData::PacketTrack;
+        expected_actions.data = ActionData::ProtoFilter | ActionData::PacketCache;
         assert!(ptree.actions == expected_actions);
 
         let mut ptree = PTree::new_empty(FilterLayer::PacketContinue);
@@ -1003,7 +1003,7 @@ mod tests {
         let mut ptree = PTree::new_empty(FilterLayer::Packet);
         ptree.add_filter(&filter.get_patterns_flat(), &datatype, &DELIVER);
         let mut expected_actions = Actions::new();
-        expected_actions.data |= ActionData::PacketTrack | ActionData::ProtoFilter;
+        expected_actions.data |= ActionData::PacketCache | ActionData::ProtoFilter;
         assert!(ptree.actions == expected_actions);
     }
 

--- a/core/src/subscription/mod.rs
+++ b/core/src/subscription/mod.rs
@@ -29,13 +29,19 @@ pub trait Trackable {
     fn track_session(&mut self, session: Session);
 
     /// Store packets for (possible) future delivery
-    fn track_packet(&mut self, mbuf: Mbuf);
+    fn buffer_packet(&mut self, pdu: &L4Pdu, actions: &Actions, reassembled: bool);
 
-    /// Get reference to stored packets
+    /// Get reference to stored packets (those buffered for delivery)
     fn packets(&self) -> &Vec<Mbuf>;
 
-    /// Drain vector of mbufs
-    fn drain_packets(&mut self);
+    /// Drain data from all types that require storing packets
+    /// Can help free mbufs for future use
+    fn drain_tracked_packets(&mut self);
+
+    /// Drain data from packets cached for future potential delivery
+    /// Used after these packets have been delivered or when associated
+    /// subscription fails to match
+    fn drain_cached_packets(&mut self);
 
     /// Return the core ID that this tracked conn. is on
     fn core_id(&self) -> &CoreId;

--- a/datatypes/src/lib.rs
+++ b/datatypes/src/lib.rs
@@ -103,7 +103,7 @@ pub trait PacketList {
     /// New packet in connection received (or reassembled, if reassembled=true)
     /// Note this may be invoked both pre- and post-reassembly; types
     /// should check `reassembled` to avoid double-counting.
-    fn update(&mut self, pdu: &L4Pdu, reassembled: bool);
+    fn track_packet(&mut self, pdu: &L4Pdu, reassembled: bool);
     /// Clear internal data; called if connection no longer matches filter
     /// that requires the Tracked type.
     fn clear(&mut self);

--- a/datatypes/src/packet_list.rs
+++ b/datatypes/src/packet_list.rs
@@ -108,7 +108,7 @@ impl PacketList for BidirPktStream {
         }
     }
 
-    fn update(&mut self, pdu: &L4Pdu, reassembled: bool) {
+    fn track_packet(&mut self, pdu: &L4Pdu, reassembled: bool) {
         if !reassembled {
             self.push(pdu);
         }
@@ -154,7 +154,7 @@ impl PacketList for OrigPktStream {
         }
     }
 
-    fn update(&mut self, pdu: &L4Pdu, reassembled: bool) {
+    fn track_packet(&mut self, pdu: &L4Pdu, reassembled: bool) {
         if pdu.dir && !reassembled {
             self.push(pdu);
         }
@@ -201,7 +201,7 @@ impl PacketList for RespPktStream {
         }
     }
 
-    fn update(&mut self, pdu: &L4Pdu, reassembled: bool) {
+    fn track_packet(&mut self, pdu: &L4Pdu, reassembled: bool) {
         if !pdu.dir && !reassembled {
             self.push(pdu);
         }
@@ -245,7 +245,7 @@ impl PacketList for OrigPktsReassembled {
         }
     }
 
-    fn update(&mut self, pdu: &L4Pdu, reassembled: bool) {
+    fn track_packet(&mut self, pdu: &L4Pdu, reassembled: bool) {
         if pdu.dir && reassembled {
             self.push(pdu);
         }
@@ -289,7 +289,7 @@ impl PacketList for RespPktsReassembled {
         }
     }
 
-    fn update(&mut self, pdu: &L4Pdu, reassembled: bool) {
+    fn track_packet(&mut self, pdu: &L4Pdu, reassembled: bool) {
         if !pdu.dir && reassembled {
             self.push(pdu);
         }
@@ -314,7 +314,7 @@ impl PacketList for BidirZcPktStream {
         }
     }
 
-    fn update(&mut self, pdu: &L4Pdu, reassembled: bool) {
+    fn track_packet(&mut self, pdu: &L4Pdu, reassembled: bool) {
         if !reassembled {
             self.packets.push(Mbuf::new_ref(&pdu.mbuf));
         }
@@ -340,7 +340,7 @@ impl PacketList for OrigZcPktStream {
         }
     }
 
-    fn update(&mut self, pdu: &L4Pdu, reassembled: bool) {
+    fn track_packet(&mut self, pdu: &L4Pdu, reassembled: bool) {
         if !reassembled && pdu.dir {
             self.packets.push(Mbuf::new_ref(&pdu.mbuf));
         }
@@ -368,7 +368,7 @@ impl PacketList for RespZcPktStream {
         }
     }
 
-    fn update(&mut self, pdu: &L4Pdu, reassembled: bool) {
+    fn track_packet(&mut self, pdu: &L4Pdu, reassembled: bool) {
         if !reassembled && !pdu.dir {
             self.packets.push(Mbuf::new_ref(&pdu.mbuf));
         }
@@ -392,7 +392,7 @@ impl PacketList for OrigZcPktsReassembled {
         }
     }
 
-    fn update(&mut self, pdu: &L4Pdu, reassembled: bool) {
+    fn track_packet(&mut self, pdu: &L4Pdu, reassembled: bool) {
         if reassembled && pdu.dir {
             self.packets.push(Mbuf::new_ref(&pdu.mbuf));
         }
@@ -416,7 +416,7 @@ impl PacketList for RespZcPktsReassembled {
         }
     }
 
-    fn update(&mut self, pdu: &L4Pdu, reassembled: bool) {
+    fn track_packet(&mut self, pdu: &L4Pdu, reassembled: bool) {
         if reassembled && !pdu.dir {
             self.packets.push(Mbuf::new_ref(&pdu.mbuf));
         }

--- a/datatypes/src/typedefs.rs
+++ b/datatypes/src/typedefs.rs
@@ -56,7 +56,8 @@ lazy_static! {
                     needs_parse: true,
                     track_sessions: true,
                     needs_update: false,
-                    needs_update_reassembled: false,
+                    needs_reassembly: false,
+                    needs_packet_track: false,
                     stream_protos: vec!["tls", "dns", "http", "quic"],
                     as_str: "SessionList",
                 }


### PR DESCRIPTION
- Performance: clear OOO buffers when reassembly is no longer needed
- Performance: drop tracked Mbufs more greedily
- Update termination heuristic - must see both FINs and both ACKs for FINs
- Some minor cleanup