### PR TITLE
Avoid mbuf size truncation to u16

### DIFF
--- a/configs/online-vdev.toml
+++ b/configs/online-vdev.toml
@@ -17,7 +17,7 @@ nb_memory_channels = 6
     duration = 60
     nb_rxd = 32768
     promiscuous = true
-    mtu = 65535
+    mtu = 64000
     hardware_assist = false
     dpdk_supl_args = ["--no-huge","--no-pci","-m 512M","--vdev=net_pcap0,iface=ens0"]
 

--- a/core/src/memory/mempool.rs
+++ b/core/src/memory/mempool.rs
@@ -9,7 +9,7 @@ use std::fmt;
 use std::os::raw::{c_int, c_uint};
 use std::ptr::NonNull;
 
-use anyhow::Result;
+use anyhow::{bail, Context, Result};
 use thiserror::Error;
 
 const RX_BUF_ALIGN: u32 = 1024;
@@ -36,7 +36,9 @@ impl Mempool {
                 config.capacity as c_uint,
                 config.cache_size as c_uint,
                 0,
-                mbuf_size as u16,
+                mbuf_size
+                    .try_into()
+                    .with_context(|| format!("mbuf size {mbuf_size} is larger than 65535, please adjust mtu"))?,
                 socket_id.raw() as c_int,
             )
         };


### PR DESCRIPTION
When mbuf_size(u32) is larger than 65535(for example `online-vdev.toml`), it is silently truncated to u16. This PR fixes it.