### PR TITLE
Add prometheus for statistics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "core",
     "datatypes",
     "examples/websites",
+    "examples/websites-prometheus",
     "examples/port_count",
     # Exclude from compilation; many subscriptions takes a long time to compile
     # "examples/filter_stats",

--- a/configs/online-vdev.toml
+++ b/configs/online-vdev.toml
@@ -21,6 +21,9 @@ nb_memory_channels = 6
     hardware_assist = false
     dpdk_supl_args = ["--no-huge","--no-pci","-m 512M","--vdev=net_pcap0,iface=ens0"]
 
+    [online.prometheus]
+        port = 9898
+
     [online.monitor.display]
         throughput = true
         mempool_usage = true

--- a/configs/online.toml
+++ b/configs/online.toml
@@ -35,6 +35,9 @@ udp_inactivity_timeout = 60000
 tcp_inactivity_timeout = 300000
 tcp_establish_timeout = 5000
 
+[online.prometheus]
+port = 9898
+
 [online.monitor.display]
 throughput = true
 mempool_usage = true

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -54,11 +54,14 @@ syn = { version = "2.0.15" }
 regex = "1.7.3"
 ring = "0.17.8"
 aes-gcm = "0.10.3"
+
+# Statistics
 tokio = { version = "1.42.0", features = ["full"] }
-hyper = { version = "0.14", features = ["full"] }
-prometheus = "0.13.4"
+hyper = { version = "1", features = ["full"] }
+hyper-util = { version = "0.1", features = ["full"] }
 array-init = "2.0"
 prometheus-client = "0.22.3"
+http-body-util = "0.1.2"
 
 [features]
 timing = []

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -58,6 +58,7 @@ tokio = { version = "1.42.0", features = ["full"] }
 hyper = { version = "0.14", features = ["full"] }
 prometheus = "0.13.4"
 array-init = "2.0"
+prometheus-client = "0.22.3"
 
 [features]
 timing = []

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -54,6 +54,10 @@ syn = { version = "2.0.15" }
 regex = "1.7.3"
 ring = "0.17.8"
 aes-gcm = "0.10.3"
+tokio = { version = "1.42.0", features = ["full"] }
+hyper = { version = "0.14", features = ["full"] }
+prometheus = "0.13.4"
+array-init = "2.0"
 
 [features]
 timing = []

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -57,13 +57,19 @@ aes-gcm = "0.10.3"
 
 # Statistics
 tokio = { version = "1.42.0", features = ["full"] }
-hyper = { version = "1", features = ["full"] }
-hyper-util = { version = "0.1", features = ["full"] }
 array-init = "2.0"
-prometheus-client = "0.22.3"
-http-body-util = "0.1.2"
+hyper = { version = "1", features = ["full"], optional = true }
+hyper-util = { version = "0.1", features = ["full"], optional = true }
+prometheus-client = { version = "0.22.3", optional = true }
+http-body-util = { version = "0.1.2", optional = true }
 
 [features]
 timing = []
+prometheus = [
+    "dep:hyper", 
+    "dep:hyper-util",
+    "dep:prometheus-client",
+    "dep:http-body-util",
+]
 mlx5 = []
 default = []

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -11,9 +11,10 @@
 
 use crate::lcore::{CoreId, SocketId};
 
-use std::net::Ipv4Addr;
+use std::fs;
+#[cfg(feature = "prometheus")]
+use std::net::{IpAddr, Ipv4Addr};
 use std::path::Path;
-use std::{fs, net::IpAddr};
 
 use serde::{Deserialize, Serialize};
 
@@ -338,6 +339,7 @@ pub struct OnlineConfig {
 
     /// Prometheus metrics exporter server. Defaults to `None`.
     #[serde(default = "default_prometheus")]
+    #[cfg(feature = "prometheus")]
     pub prometheus: Option<PrometheusConfig>,
 
     /// List of network interfaces to read from.
@@ -372,6 +374,7 @@ fn default_monitor() -> Option<MonitorConfig> {
     None
 }
 
+#[cfg(feature = "prometheus")]
 fn default_prometheus() -> Option<PrometheusConfig> {
     None
 }
@@ -494,6 +497,7 @@ fn default_log() -> Option<LogConfig> {
 ///     interval = 1000
 /// ```
 #[derive(Deserialize, Serialize, Debug, Clone, Copy)]
+#[cfg(feature = "prometheus")]
 pub struct PrometheusConfig {
     /// Listen port for Prometheus metrics.
     pub port: u16,
@@ -503,6 +507,7 @@ pub struct PrometheusConfig {
     pub ip: IpAddr,
 }
 
+#[cfg(feature = "prometheus")]
 fn default_prometheus_ip() -> IpAddr {
     IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))
 }

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -11,8 +11,9 @@
 
 use crate::lcore::{CoreId, SocketId};
 
-use std::fs;
+use std::net::Ipv4Addr;
 use std::path::Path;
+use std::{fs, net::IpAddr};
 
 use serde::{Deserialize, Serialize};
 
@@ -335,6 +336,10 @@ pub struct OnlineConfig {
     #[serde(default = "default_monitor")]
     pub monitor: Option<MonitorConfig>,
 
+    /// Prometheus metrics exporter server. Defaults to `None`.
+    #[serde(default = "default_prometheus")]
+    pub prometheus: Option<PrometheusConfig>,
+
     /// List of network interfaces to read from.
     pub ports: Vec<PortMap>,
 }
@@ -364,6 +369,10 @@ fn default_mtu() -> usize {
 }
 
 fn default_monitor() -> Option<MonitorConfig> {
+    None
+}
+
+fn default_prometheus() -> Option<PrometheusConfig> {
     None
 }
 
@@ -470,6 +479,32 @@ fn default_display() -> Option<DisplayConfig> {
 
 fn default_log() -> Option<LogConfig> {
     None
+}
+
+/// Statistics logging and live monitoring operations.
+///
+/// ## Example
+/// ```toml
+/// [online.monitor.display]
+///     throughput = true
+///     mempool_usage = true
+///
+/// [online.monitor.log]
+///     directory = "./log"
+///     interval = 1000
+/// ```
+#[derive(Deserialize, Serialize, Debug, Clone, Copy)]
+pub struct PrometheusConfig {
+    /// Listen port for Prometheus metrics.
+    pub port: u16,
+
+    /// Listen bind address for Prometheus metrics. Defaults to `127.0.0.1`.
+    #[serde(default = "default_prometheus_ip")]
+    pub ip: IpAddr,
+}
+
+fn default_prometheus_ip() -> IpAddr {
+    IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))
 }
 
 /* --------------------------------------------------------------------------------- */

--- a/core/src/conntrack/conn/mod.rs
+++ b/core/src/conntrack/conn/mod.rs
@@ -15,6 +15,9 @@ use crate::conntrack::pdu::{L4Context, L4Pdu};
 use crate::lcore::CoreId;
 use crate::protocols::packet::tcp::{ACK, RST, SYN};
 use crate::protocols::stream::ParserRegistry;
+use crate::stats::{
+    StatExt, DROPPED_MIDDLE_OF_CONNECTION_TCP_BYTE, DROPPED_MIDDLE_OF_CONNECTION_TCP_PKT,
+};
 use crate::subscription::{Subscription, Trackable};
 
 use anyhow::{bail, Result};
@@ -63,6 +66,8 @@ where
         {
             TcpConn::new_on_syn(pdu.ctxt, max_ooo)
         } else {
+            DROPPED_MIDDLE_OF_CONNECTION_TCP_PKT.inc();
+            DROPPED_MIDDLE_OF_CONNECTION_TCP_BYTE.inc_by(pdu.mbuf.data_len() as u64);
             bail!("Not SYN")
         };
         Ok(Conn {

--- a/core/src/conntrack/mod.rs
+++ b/core/src/conntrack/mod.rs
@@ -19,6 +19,7 @@ use crate::memory::mbuf::Mbuf;
 use crate::protocols::packet::tcp::TCP_PROTOCOL;
 use crate::protocols::packet::udp::UDP_PROTOCOL;
 use crate::protocols::stream::ParserRegistry;
+use crate::stats::{StatExt, TCP_NEW_CONNECTIONS, UDP_NEW_CONNECTIONS};
 use crate::subscription::{Subscription, Trackable};
 
 use std::cmp;
@@ -148,6 +149,15 @@ where
                                 conn.last_seen_ts,
                                 conn.inactivity_window,
                             );
+                            match ctxt.proto {
+                                TCP_PROTOCOL => {
+                                    TCP_NEW_CONNECTIONS.inc();
+                                }
+                                UDP_PROTOCOL => {
+                                    UDP_NEW_CONNECTIONS.inc();
+                                }
+                                _ => {}
+                            }
                             self.table.insert(conn_id, conn);
                         }
                     }

--- a/core/src/lcore/monitor.rs
+++ b/core/src/lcore/monitor.rs
@@ -53,7 +53,6 @@ impl Monitor {
             if let Some(monitor_cfg) = &online_cfg.monitor {
                 if let Some(display_cfg) = &monitor_cfg.display {
                     return Some(Display {
-                        ticker: tick(Duration::from_millis(1000)),
                         throughput: display_cfg.throughput,
                         keywords: display_cfg.port_stats.clone(),
                     });
@@ -106,7 +105,7 @@ impl Monitor {
         }
     }
 
-    pub(crate) fn run(&mut self) {
+    pub(crate) async fn run(&mut self) {
         if let Some(logger) = &mut self.logger {
             logger.init_port_wtrs().expect("port logger init");
         }
@@ -120,8 +119,9 @@ impl Monitor {
         let mut prev_rx = init_rx;
         let mut prev_ts = init_ts;
         let mut init = true;
+        let mut ticker = tokio::time::interval(Duration::from_millis(1000));
         // Add a small delay to allow workers to start polling for packets
-        std::thread::sleep(Duration::from_millis(1000));
+        tokio::time::sleep(Duration::from_millis(1000)).await;
         while self.is_running.load(Ordering::Relaxed) {
             if let Some(duration) = self.duration {
                 if start_ts.elapsed() >= duration {
@@ -130,30 +130,29 @@ impl Monitor {
             }
 
             if let Some(display) = &self.display {
-                if display.ticker.try_recv().is_ok() {
-                    let curr_ts = Instant::now();
-                    let delta = curr_ts - prev_ts;
-                    match AggRxStats::collect(&self.ports, &display.keywords) {
-                        Ok(curr_rx) => {
-                            let nms = delta.as_millis() as f64;
-                            if init {
-                                init_rx = curr_rx;
-                                init_ts = curr_ts;
-                                init = false;
-                            }
-                            if display.throughput {
-                                println!("----------------------------------------------");
-                                println!("Current time: {}s", (curr_ts - start_ts).as_secs());
-                                display.mempool_usage(&self.ports);
-                                AggRxStats::display_rates(curr_rx, prev_rx, nms);
-                                AggRxStats::display_dropped(curr_rx, init_rx);
-                            }
-                            prev_rx = curr_rx;
-                            prev_ts = curr_ts;
+                ticker.tick().await;
+                let curr_ts = Instant::now();
+                let delta = curr_ts - prev_ts;
+                match AggRxStats::collect(&self.ports, &display.keywords) {
+                    Ok(curr_rx) => {
+                        let nms = delta.as_millis() as f64;
+                        if init {
+                            init_rx = curr_rx;
+                            init_ts = curr_ts;
+                            init = false;
                         }
-                        Err(error) => {
-                            log::error!("Monitor display error: {}", error);
+                        if display.throughput {
+                            println!("----------------------------------------------");
+                            println!("Current time: {}s", (curr_ts - start_ts).as_secs());
+                            display.mempool_usage(&self.ports);
+                            AggRxStats::display_rates(curr_rx, prev_rx, nms);
+                            AggRxStats::display_dropped(curr_rx, init_rx);
                         }
+                        prev_rx = curr_rx;
+                        prev_ts = curr_ts;
+                    }
+                    Err(error) => {
+                        log::error!("Monitor display error: {}", error);
                     }
                 }
             }
@@ -168,7 +167,7 @@ impl Monitor {
             }
         }
 
-        std::thread::sleep(Duration::from_millis(100));
+        tokio::time::sleep(Duration::from_millis(1000)).await;
         println!("----------------------------------------------");
         let tputs = Throughputs::new(prev_rx, init_rx, (prev_ts - init_ts).as_millis() as f64);
         println!("{}", tputs);
@@ -182,7 +181,6 @@ impl Monitor {
 
 #[derive(Debug)]
 struct Display {
-    ticker: Receiver<Instant>,
     throughput: bool,
     keywords: Vec<String>,
 }

--- a/core/src/lcore/rx_core.rs
+++ b/core/src/lcore/rx_core.rs
@@ -24,6 +24,7 @@ where
     pub(crate) id: CoreId,
     pub(crate) rxqueues: Vec<RxQueue>,
     pub(crate) conntrack: ConnTrackConfig,
+    pub(crate) is_prometheus_enabled: bool,
     pub(crate) subscription: Arc<Subscription<S>>,
     pub(crate) is_running: Arc<AtomicBool>,
 }
@@ -36,6 +37,7 @@ where
         core_id: CoreId,
         rxqueues: Vec<RxQueue>,
         conntrack: ConnTrackConfig,
+        is_prometheus_enabled: bool,
         subscription: Arc<Subscription<S>>,
         is_running: Arc<AtomicBool>,
     ) -> Self {
@@ -43,6 +45,7 @@ where
             id: core_id,
             rxqueues,
             conntrack,
+            is_prometheus_enabled,
             subscription,
             is_running,
         }
@@ -95,7 +98,7 @@ where
                 let mbufs: Vec<Mbuf> = self.rx_burst(rxqueue, 32);
                 if mbufs.is_empty() {
                     IDLE_CYCLES.inc();
-                    if IDLE_CYCLES.get() & 1023 == 0 {
+                    if IDLE_CYCLES.get() & 1023 == 0 && self.is_prometheus_enabled {
                         update_thread_local_stats(self.id);
                     }
                 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -82,7 +82,7 @@ pub mod memory;
 mod port;
 pub mod protocols;
 mod runtime;
-mod stats;
+pub mod stats;
 #[doc(hidden)]
 pub mod subscription;
 pub mod utils;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -82,6 +82,7 @@ pub mod memory;
 mod port;
 pub mod protocols;
 mod runtime;
+mod stats;
 #[doc(hidden)]
 pub mod subscription;
 pub mod utils;

--- a/core/src/stats.rs
+++ b/core/src/stats.rs
@@ -2,9 +2,15 @@ use hyper::{header::CONTENT_TYPE, Body, Request, Response};
 use prometheus::{
     register_int_counter, Counter, Encoder, Gauge, HistogramVec, IntCounter, Opts, TextEncoder,
 };
+use prometheus_client::{
+    encoding::EncodeLabelSet,
+    metrics::family::Family,
+    registry::{Registry, Unit},
+};
 use std::{
     cell::{Cell, OnceCell},
-    sync::LazyLock,
+    fmt::Write,
+    sync::{LazyLock, Mutex},
 };
 
 use lazy_static::lazy_static;
@@ -12,16 +18,59 @@ use prometheus::{labels, opts, register_counter, register_gauge, register_histog
 
 use crate::CoreId;
 
+impl EncodeLabelSet for CoreId {
+    fn encode(
+        &self,
+        mut encoder: prometheus_client::encoding::LabelSetEncoder,
+    ) -> Result<(), std::fmt::Error> {
+        let mut label = encoder.encode_label();
+        let mut key = label.encode_label_key()?;
+        key.write_str("core")?;
+        let mut value = key.encode_label_value()?;
+        write!(value, "{}", self.0)?;
+        value.finish()
+    }
+}
+
+#[derive(Default)]
+pub struct Families {
+    total_byte: Family<CoreId, prometheus_client::metrics::counter::Counter>,
+}
+
+pub static FAMILIES: LazyLock<Families> = LazyLock::new(Families::default);
+
 pub struct DpdkPrometheusStats {
-    pub ingress_bits: IntCounter,
+    pub ingress_bits: prometheus_client::metrics::counter::Counter,
     pub ingress_pkts: IntCounter,
     pub good_bits: IntCounter,
-    pub good_pkts: IntCounter,
+    pub good_pkts: prometheus_client::metrics::counter::Counter,
     pub process_bits: IntCounter,
     pub process_pkts: IntCounter,
     pub hw_dropped_pkts: IntCounter,
     pub sw_dropped_pkts: IntCounter,
 }
+
+pub static STAT_REGISTRY: LazyLock<Registry> = LazyLock::new(|| {
+    let mut r = Registry::default();
+    r.register_with_unit(
+        "ingress_bits",
+        "Number of bits received by the NIC.",
+        Unit::Bytes,
+        DPDK_STATS.ingress_bits.clone(),
+    );
+    r.register(
+        "good_pkts",
+        "Number of packets received by the DPDK.",
+        DPDK_STATS.good_pkts.clone(),
+    );
+    r.register_with_unit(
+        "total_byte",
+        "Number of total bytes received from dpdk.",
+        Unit::Bytes,
+        FAMILIES.total_byte.clone(),
+    );
+    r
+});
 
 pub static DPDK_STATS: LazyLock<DpdkPrometheusStats> = LazyLock::new(|| DpdkPrometheusStats {
     ingress_pkts: register_int_counter!(Opts::new(
@@ -29,16 +78,8 @@ pub static DPDK_STATS: LazyLock<DpdkPrometheusStats> = LazyLock::new(|| DpdkProm
         "Number of packets received by the NIC."
     ))
     .unwrap(),
-    ingress_bits: register_int_counter!(Opts::new(
-        "ingress_bits",
-        "Number of bits received by the NIC."
-    ))
-    .unwrap(),
-    good_pkts: register_int_counter!(Opts::new(
-        "good_pkts",
-        "Number of packets received by the DPDK."
-    ))
-    .unwrap(),
+    ingress_bits: prometheus_client::metrics::counter::Counter::default(),
+    good_pkts: prometheus_client::metrics::counter::Counter::default(),
     good_bits: register_int_counter!(Opts::new(
         "good_bits",
         "Number of bits received by the DPDK."
@@ -72,7 +113,7 @@ struct PerCorePrometheusStats {
     dropped_middle_of_connection_tcp_pkt: IntCounter,
     dropped_middle_of_connection_tcp_byte: IntCounter,
     total_pkt: IntCounter,
-    total_byte: IntCounter,
+    total_byte: prometheus_client::metrics::counter::Counter,
     idle_cycles: IntCounter,
     total_cycles: IntCounter,
 }
@@ -102,10 +143,10 @@ impl StatExt for std::thread::LocalKey<Cell<u64>> {
     }
 }
 
-pub fn update_thread_local_stats(core_id: CoreId) {
+pub fn update_thread_local_stats(core: CoreId) {
     PROMETHEUS.with(|pr| {
         let pr = pr.get_or_init(|| {
-            let core_id = core_id.0 as usize;
+            let core_id = core.0 as usize;
             PerCorePrometheusStats {
                 ignored_by_packet_filter_pkt: register_int_counter!(Opts::new(
                     "ignored_by_packet_filter_pkt",
@@ -137,12 +178,7 @@ pub fn update_thread_local_stats(core_id: CoreId) {
                 )
                 .const_label("core", format!("{core_id}")))
                 .unwrap(),
-                total_byte: register_int_counter!(Opts::new(
-                    "total_byte",
-                    "Number of total bytes received from dpdk."
-                )
-                .const_label("core", format!("{core_id}")))
-                .unwrap(),
+                total_byte: FAMILIES.total_byte.get_or_create(&core).clone(),
                 idle_cycles: register_int_counter!(Opts::new(
                     "idle_cycles",
                     "Number of polling loop iterations that had no packet."
@@ -208,13 +244,17 @@ pub async fn serve_req(_req: Request<Body>) -> Result<Response<Body>, hyper::Err
     let timer = HTTP_REQ_HISTOGRAM.with_label_values(&["all"]).start_timer();
 
     let metric_families = prometheus::gather();
-    let mut buffer = vec![];
-    encoder.encode(&metric_families, &mut buffer).unwrap();
+    let mut buffer = String::new();
+    prometheus_client::encoding::text::encode(&mut buffer, &STAT_REGISTRY).unwrap();
+    // encoder.encode(&metric_families, &mut buffer).unwrap();
     HTTP_BODY_GAUGE.set(buffer.len() as f64);
 
     let response = Response::builder()
         .status(200)
-        .header(CONTENT_TYPE, encoder.format_type())
+        .header(
+            CONTENT_TYPE,
+            "application/openmetrics-text; version=1.0.0; charset=utf-8",
+        )
         .body(Body::from(buffer))
         .unwrap();
 

--- a/core/src/stats.rs
+++ b/core/src/stats.rs
@@ -1,0 +1,167 @@
+use hyper::{header::CONTENT_TYPE, Body, Request, Response};
+use prometheus::{
+    register_int_counter, Counter, Encoder, Gauge, HistogramVec, IntCounter, Opts, TextEncoder,
+};
+use std::cell::{Cell, OnceCell};
+
+use lazy_static::lazy_static;
+use prometheus::{labels, opts, register_counter, register_gauge, register_histogram_vec};
+
+use crate::CoreId;
+
+struct PerCorePrometheusStats {
+    ignored_by_packet_filter_pkt: IntCounter,
+    ignored_by_packet_filter_byte: IntCounter,
+    dropped_middle_of_connection_tcp_pkt: IntCounter,
+    dropped_middle_of_connection_tcp_byte: IntCounter,
+    total_pkt: IntCounter,
+    total_byte: IntCounter,
+    idle_cycles: IntCounter,
+    total_cycles: IntCounter,
+}
+
+thread_local! {
+    pub static IGNORED_BY_PACKET_FILTER_PKT: Cell<u64> = Cell::new(0);
+    pub static IGNORED_BY_PACKET_FILTER_BYTE: Cell<u64> = Cell::new(0);
+    pub static DROPPED_MIDDLE_OF_CONNECTION_TCP_PKT: Cell<u64> = Cell::new(0);
+    pub static DROPPED_MIDDLE_OF_CONNECTION_TCP_BYTE: Cell<u64> = Cell::new(0);
+    pub static TOTAL_PKT: Cell<u64> = Cell::new(0);
+    pub static TOTAL_BYTE: Cell<u64> = Cell::new(0);
+    pub static IDLE_CYCLES: Cell<u64> = Cell::new(0);
+    pub static TOTAL_CYCLES: Cell<u64> = Cell::new(0);
+    pub static PROMETHEUS: OnceCell<PerCorePrometheusStats> = OnceCell::new();
+}
+
+pub trait StatExt: Sized {
+    fn inc(&'static self) {
+        self.inc_by(1);
+    }
+    fn inc_by(&'static self, val: u64);
+}
+
+impl StatExt for std::thread::LocalKey<Cell<u64>> {
+    fn inc_by(&'static self, val: u64) {
+        self.set(self.get() + val);
+    }
+}
+
+pub fn update_thread_local_stats(core_id: CoreId) {
+    PROMETHEUS.with(|pr| {
+        let pr = pr.get_or_init(|| {
+            let core_id = core_id.0 as usize;
+            PerCorePrometheusStats {
+                ignored_by_packet_filter_pkt: register_int_counter!(Opts::new(
+                    "ignored_by_packet_filter_pkt",
+                    "Number of packets ignored by packet filter."
+                )
+                .const_label("core", format!("{core_id}")))
+                .unwrap(),
+                ignored_by_packet_filter_byte: register_int_counter!(Opts::new(
+                    "ignored_by_packet_filter_byte",
+                    "Number of bytes ignored by packet filter."
+                )
+                .const_label("core", format!("{core_id}")))
+                .unwrap(),
+                dropped_middle_of_connection_tcp_pkt: register_int_counter!(Opts::new(
+                    "dropped_middle_of_connection_tcp_pkt",
+                    "Number of packets dropped due missing SYN packet."
+                )
+                .const_label("core", format!("{core_id}")))
+                .unwrap(),
+                dropped_middle_of_connection_tcp_byte: register_int_counter!(Opts::new(
+                    "dropped_middle_of_connection_tcp_byte",
+                    "Number of bytes dropped due missing SYN packet."
+                )
+                .const_label("core", format!("{core_id}")))
+                .unwrap(),
+                total_pkt: register_int_counter!(Opts::new(
+                    "total_pkt",
+                    "Number of total packets received from dpdk."
+                )
+                .const_label("core", format!("{core_id}")))
+                .unwrap(),
+                total_byte: register_int_counter!(Opts::new(
+                    "total_byte",
+                    "Number of total bytes received from dpdk."
+                )
+                .const_label("core", format!("{core_id}")))
+                .unwrap(),
+                idle_cycles: register_int_counter!(Opts::new(
+                    "idle_cycles",
+                    "Number of polling loop iterations that had no packet."
+                )
+                .const_label("core", format!("{core_id}")))
+                .unwrap(),
+                total_cycles: register_int_counter!(Opts::new(
+                    "total_cycles",
+                    "Number of total polling loop iterations."
+                )
+                .const_label("core", format!("{core_id}")))
+                .unwrap(),
+            }
+        });
+        pr.ignored_by_packet_filter_pkt
+            .inc_by(IGNORED_BY_PACKET_FILTER_PKT.get());
+        IGNORED_BY_PACKET_FILTER_PKT.set(0);
+        pr.ignored_by_packet_filter_byte
+            .inc_by(IGNORED_BY_PACKET_FILTER_BYTE.get());
+        IGNORED_BY_PACKET_FILTER_BYTE.set(0);
+        pr.dropped_middle_of_connection_tcp_pkt
+            .inc_by(DROPPED_MIDDLE_OF_CONNECTION_TCP_PKT.get());
+        DROPPED_MIDDLE_OF_CONNECTION_TCP_PKT.set(0);
+        pr.dropped_middle_of_connection_tcp_byte
+            .inc_by(DROPPED_MIDDLE_OF_CONNECTION_TCP_BYTE.get());
+        DROPPED_MIDDLE_OF_CONNECTION_TCP_BYTE.set(0);
+        pr.total_pkt.inc_by(TOTAL_PKT.get());
+        TOTAL_PKT.set(0);
+        pr.total_byte.inc_by(TOTAL_BYTE.get());
+        TOTAL_BYTE.set(0);
+        pr.idle_cycles.inc_by(IDLE_CYCLES.get());
+        IDLE_CYCLES.set(0);
+        pr.total_cycles.inc_by(TOTAL_CYCLES.get());
+        TOTAL_CYCLES.set(0);
+    });
+}
+
+lazy_static! {
+    static ref HTTP_COUNTER: Counter = register_counter!(opts!(
+        "example_http_requests_total",
+        "Number of HTTP requests made.",
+        labels! {"handler" => "all",}
+    ))
+    .unwrap();
+    static ref HTTP_BODY_GAUGE: Gauge = register_gauge!(opts!(
+        "example_http_response_size_bytes",
+        "The HTTP response sizes in bytes.",
+        labels! {"handler" => "all",}
+    ))
+    .unwrap();
+    static ref HTTP_REQ_HISTOGRAM: HistogramVec = register_histogram_vec!(
+        "example_http_request_duration_seconds",
+        "The HTTP request latencies in seconds.",
+        &["handler"]
+    )
+    .unwrap();
+}
+
+pub async fn serve_req(_req: Request<Body>) -> Result<Response<Body>, hyper::Error> {
+    let encoder = TextEncoder::new();
+
+    HTTP_COUNTER.inc();
+    let timer = HTTP_REQ_HISTOGRAM.with_label_values(&["all"]).start_timer();
+
+    let metric_families = prometheus::gather();
+    let mut buffer = vec![];
+    encoder.encode(&metric_families, &mut buffer).unwrap();
+    HTTP_BODY_GAUGE.set(buffer.len() as f64);
+
+    let response = Response::builder()
+        .status(200)
+        .header(CONTENT_TYPE, encoder.format_type())
+        .body(Body::from(buffer))
+        .unwrap();
+
+    timer.observe_duration();
+
+    Ok(response)
+}

--- a/core/src/stats.rs
+++ b/core/src/stats.rs
@@ -4,7 +4,12 @@
 //! analysing retina usage over time. You can use Prometheus with other services like Grafana to use the
 //! reported data.
 //!
-//! Retina runs a http server on 127.0.0.1:9898 by default, so you
+//! You can enable a exporter http server from `online.prometheus` config:
+//! ```toml
+//! [online.prometheus]
+//!     port = 9898
+//! ```
+//! Then you
 //! can [install Prometheus](https://prometheus.io/docs/prometheus/latest/installation/) and
 //! use this config to scrape metrics from Retina:
 //!
@@ -25,7 +30,7 @@
 //! ```
 //! shows the number of received packets per second. For more complex usages, see
 //! [Prometheus docs](https://prometheus.io/docs/introduction/overview/).
-//! 
+//!
 //! You can also use the [`register_base_prometheus_registry`] function
 //! to add your own metrics to the prometheus registry.
 
@@ -66,10 +71,8 @@ impl EncodeLabelSet for CoreId {
 struct Families {
     ignored_by_packet_filter_pkt: Family<CoreId, Counter>,
     ignored_by_packet_filter_byte: Family<CoreId, Counter>,
-    dropped_middle_of_connection_tcp_pkt:
-        Family<CoreId, Counter>,
-    dropped_middle_of_connection_tcp_byte:
-        Family<CoreId, Counter>,
+    dropped_middle_of_connection_tcp_pkt: Family<CoreId, Counter>,
+    dropped_middle_of_connection_tcp_byte: Family<CoreId, Counter>,
     total_pkt: Family<CoreId, Counter>,
     total_byte: Family<CoreId, Counter>,
     tcp_pkt: Family<CoreId, Counter>,
@@ -372,7 +375,9 @@ pub(crate) fn update_thread_local_stats(core: CoreId) {
     });
 }
 
-pub(crate) async fn serve_req(_req: Request<impl Body>) -> Result<Response<Full<Bytes>>, hyper::Error> {
+pub(crate) async fn serve_req(
+    _req: Request<impl Body>,
+) -> Result<Response<Full<Bytes>>, hyper::Error> {
     let mut buffer = String::new();
     prometheus_client::encoding::text::encode(&mut buffer, &STAT_REGISTRY).unwrap();
 

--- a/core/src/stats.rs
+++ b/core/src/stats.rs
@@ -1,3 +1,31 @@
+//! Prometheus statistics.
+//!
+//! Retina uses the Prometheus time series database to record and report metrics useful for monitoring and
+//! analysing retina usage over time. You can use Prometheus with other services like Grafana to use the
+//! reported data.
+//!
+//! Retina runs a http server on 127.0.0.1:9898 by default, so you
+//! can [install Prometheus](https://prometheus.io/docs/prometheus/latest/installation/) and
+//! use this config to scrape metrics from Retina:
+//!
+//! ```yaml
+//! global:
+//!     scrape_interval: 1s
+//!     evaluation_interval: 1s
+//! scrape_configs:
+//!     - job_name: retina
+//!       static_configs:
+//!           - targets: ['127.0.0.1:9898']
+//! ```
+//!
+//! After running prometheus, you can see simple graph of a prometheus query using its
+//! web gui, for example:
+//! ```txt
+//! rate(retina_worker_received_pkts[10s])
+//! ```
+//! shows the number of received packets per second. For more complex usages, see
+//! [Prometheus docs](https://prometheus.io/docs/introduction/overview/).
+
 use http_body_util::Full;
 use hyper::{
     body::{Body, Bytes},

--- a/core/src/stats/mod.rs
+++ b/core/src/stats/mod.rs
@@ -1,0 +1,40 @@
+use std::cell::Cell;
+
+#[cfg(feature = "prometheus")]
+mod prometheus;
+
+#[cfg(feature = "prometheus")]
+pub use prometheus::*;
+
+thread_local! {
+    pub(crate) static IGNORED_BY_PACKET_FILTER_PKT: Cell<u64> = const { Cell::new(0) };
+    pub(crate) static IGNORED_BY_PACKET_FILTER_BYTE: Cell<u64> = const { Cell::new(0) };
+    pub(crate) static DROPPED_MIDDLE_OF_CONNECTION_TCP_PKT: Cell<u64> = const { Cell::new(0) };
+    pub(crate) static DROPPED_MIDDLE_OF_CONNECTION_TCP_BYTE: Cell<u64> = const { Cell::new(0) };
+    pub(crate) static TOTAL_PKT: Cell<u64> = const { Cell::new(0) };
+    pub(crate) static TOTAL_BYTE: Cell<u64> = const { Cell::new(0) };
+    pub(crate) static TCP_PKT: Cell<u64> = const { Cell::new(0) };
+    pub(crate) static TCP_BYTE: Cell<u64> = const { Cell::new(0) };
+    pub(crate) static UDP_PKT: Cell<u64> = const { Cell::new(0) };
+    pub(crate) static UDP_BYTE: Cell<u64> = const { Cell::new(0) };
+    pub(crate) static TCP_NEW_CONNECTIONS: Cell<u64> = const { Cell::new(0) };
+    pub(crate) static UDP_NEW_CONNECTIONS: Cell<u64> = const { Cell::new(0) };
+    pub(crate) static IDLE_CYCLES: Cell<u64> = const { Cell::new(0) };
+    pub(crate) static TOTAL_CYCLES: Cell<u64> = const { Cell::new(0) };
+
+    #[cfg(feature = "prometheus")]
+    pub(crate) static PROMETHEUS: std::cell::OnceCell<prometheus::PerCorePrometheusStats> = const { std::cell::OnceCell::new() };
+}
+
+pub(crate) trait StatExt: Sized {
+    fn inc(&'static self) {
+        self.inc_by(1);
+    }
+    fn inc_by(&'static self, val: u64);
+}
+
+impl StatExt for std::thread::LocalKey<Cell<u64>> {
+    fn inc_by(&'static self, val: u64) {
+        self.set(self.get() + val);
+    }
+}

--- a/examples/websites-prometheus/Cargo.toml
+++ b/examples/websites-prometheus/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "websites-prometheus"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+clap = { version = "3.2.23", features = ["derive"] }
+env_logger = "0.8.4"
+retina-core = { path = "../../core" }
+retina-filtergen = { path = "../../filtergen" }
+retina-datatypes = { path = "../../datatypes" }
+prometheus-client = "0.22.3"

--- a/examples/websites-prometheus/Cargo.toml
+++ b/examples/websites-prometheus/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 clap = { version = "3.2.23", features = ["derive"] }
 env_logger = "0.8.4"
-retina-core = { path = "../../core" }
+retina-core = { path = "../../core", features = ["prometheus"] }
 retina-filtergen = { path = "../../filtergen" }
 retina-datatypes = { path = "../../datatypes" }
 prometheus-client = "0.22.3"

--- a/examples/websites-prometheus/README.md
+++ b/examples/websites-prometheus/README.md
@@ -1,0 +1,3 @@
+# Websites Prometheus
+
+Records URLs visited by protocol and stores them in the Prometheus.

--- a/examples/websites-prometheus/src/main.rs
+++ b/examples/websites-prometheus/src/main.rs
@@ -1,0 +1,85 @@
+use prometheus_client::encoding::EncodeLabelSet;
+use prometheus_client::metrics::counter::Counter;
+use prometheus_client::metrics::family::Family;
+use prometheus_client::registry::Registry;
+use retina_core::config::load_config;
+use retina_core::{stats::register_base_prometheus_registry, CoreId, Runtime};
+use retina_datatypes::*;
+use retina_filtergen::{filter, retina_main};
+
+use clap::Parser;
+use std::path::PathBuf;
+use std::sync::LazyLock;
+
+#[derive(Parser, Debug)]
+struct Args {
+    #[clap(short, long, parse(from_os_str), value_name = "FILE")]
+    config: PathBuf,
+}
+
+// Note: Using unbounded and high cardinality label set (like website field here) is bad practice
+// and can lead to high memory and disk usage in Prometheus. This is just an example.
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+struct Labels {
+    protocol: &'static str,
+    website: String,
+    core_id: u32,
+}
+
+static FAMILY: LazyLock<Family<Labels, Counter>> = LazyLock::new(Family::default);
+
+fn init() {
+    let mut r = Registry::default();
+    r.register(
+        "myapp_site_hits",
+        "Number of callback calls per each website and protocol",
+        FAMILY.clone(),
+    );
+    register_base_prometheus_registry(r);
+}
+
+fn write_result(protocol: &'static str, website: String, core_id: &CoreId) {
+    if website.is_empty() {
+        return;
+    } // Would it be helpful to count these?
+    FAMILY
+        .get_or_create(&Labels {
+            protocol,
+            website,
+            core_id: core_id.raw(),
+        })
+        .inc();
+}
+
+#[filter("dns")]
+fn dns_cb(dns: &DnsTransaction, core_id: &CoreId) {
+    let query_domain = (*dns).query_domain().to_string();
+    write_result("dns", query_domain, core_id);
+}
+
+#[filter("http")]
+fn http_cb(http: &HttpTransaction, core_id: &CoreId) {
+    let uri = (*http).uri().to_string();
+    write_result("http", uri, core_id);
+}
+
+#[filter("tls")]
+fn tls_cb(tls: &TlsHandshake, core_id: &CoreId) {
+    let sni = (*tls).sni().to_string();
+    write_result("tls", sni, core_id);
+}
+
+#[filter("quic")]
+fn quic_cb(quic: &QuicStream, core_id: &CoreId) {
+    let sni = quic.tls.sni().to_string();
+    write_result("quic", sni, core_id);
+}
+
+#[retina_main(4)]
+fn main() {
+    init();
+    let args = Args::parse();
+    let config = load_config(&args.config);
+    let mut runtime: Runtime<SubscribedWrapper> = Runtime::new(config, filter).unwrap();
+    runtime.run();
+}


### PR DESCRIPTION
This PR adds some statistics using prometheus. Prometheus is a time series database which is widely used for collecting metrics.

![image](https://github.com/user-attachments/assets/75ab8bae-e3d2-4a1d-b5c1-edbc93e659c5)

This is a per core chart of total bits per second. It is on my local machine with a fake traffic so it is in order of Kbit/s.

I put some effort in making the statistics cost negligible. I store them in thread local variables, and flush them into the atomic ones occasionally (currently every 1000 idle iterations). I also made a parameter for each core even for stats that their per core versions doesn't matter much, in order to prevent contention. To run the prometheus server, I used the main core. Previously it did only monitorings, now it does monitoring and runs a http server for prometheus concurrently using a single threaded tokio runtime.