### PR TITLE
Add support for DPDK 24.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
         dpdk_version:
           - "20.11"
           - "23.11"
+          - "24.11"
     env:
       DPDK_VERSION: ${{ matrix.dpdk_version }}
     runs-on: ubuntu-latest
@@ -43,18 +44,25 @@ jobs:
       run: |
           sudo apt-get update
           sudo apt-get install libpcap-dev libnuma-dev
-    - name: DPDK
+    - name: Cache DPDK
+      id: cache-dpdk
+      uses: actions/cache@v4
+      with:
+        path: dpdk-${{ matrix.dpdk_version }}
+        key: ${{ runner.os }}-dpdk-${{ matrix.dpdk_version }}
+    - name: Export enviroment variables
+      run: |
+          echo "PKG_CONFIG_PATH=$(pwd)/dpdk-$DPDK_VERSION/install/lib/x86_64-linux-gnu/pkgconfig/" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$(pwd)/dpdk-$DPDK_VERSION/install/lib/x86_64-linux-gnu/" >> $GITHUB_ENV
+          echo "DPDK_PATH=$(pwd)/dpdk-$DPDK_VERSION/install/" >> $GITHUB_ENV
+    - name: Retrive or compile DPDK
+      if: steps.cache-dpdk.outputs.cache-hit != 'true'
       run: |
             echo "Compiling DPDK..." ;
-            export STABLE=
-            export VERSION=${{ matrix.dpdk_version }}
-            export PKG_CONFIG_PATH=$(pwd)/dpdk-$STABLE$VERSION/install/lib/x86_64-linux-gnu/pkgconfig/ ;
-            export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$(pwd)/dpdk-$STABLE$VERSION/install/lib/x86_64-linux-gnu/ ;
-            export DPDK_PATH=$(pwd)/dpdk-$STABLE$VERSION/install/
-            if [ ! -e "dpdk-$STABLE$VERSION" ] || ! pkg-config --exists libdpdk ; then
-                wget http://fast.dpdk.org/rel/dpdk-$VERSION.tar.gz &&
-                tar -zxf dpdk-$VERSION.tar.gz &&
-                cd dpdk-$STABLE$VERSION &&
+            if [ ! -e "dpdk-$DPDK_VERSION" ] || ! pkg-config --exists libdpdk ; then
+                wget http://fast.dpdk.org/rel/dpdk-$DPDK_VERSION.tar.gz &&
+                tar -zxf dpdk-$DPDK_VERSION.tar.gz &&
+                cd dpdk-$DPDK_VERSION &&
                 pip3 install meson ninja &&
                 meson -Dprefix=$(pwd)/install/ build &&
                 cd build &&
@@ -63,9 +71,6 @@ jobs:
                 cd .. &&
                 cd .. ;
             fi
-            echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH" >> $GITHUB_ENV
-            echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH" >> $GITHUB_ENV
-            echo "DPDK_PATH=$DPDK_PATH" >> $GITHUB_ENV
     - name: Clippy retina-core (no mlx5)
       run: cargo clippy --manifest-path core/Cargo.toml --no-default-features -- --deny warnings
     - name: Unit test retina-core (no mlx5)

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -35,18 +35,25 @@ jobs:
       run: |
           sudo apt-get update
           sudo apt-get install libpcap-dev
-    - name: DPDK
+    - name: Cache DPDK
+      id: cache-dpdk
+      uses: actions/cache@v4
+      with:
+        path: dpdk-$DPDK_VERSION
+        key: ${{ runner.os }}-dpdk-$DPDK_VERSION
+    - name: Export enviroment variables
+      run: |
+          echo "PKG_CONFIG_PATH=$(pwd)/dpdk-$DPDK_VERSION/install/lib/x86_64-linux-gnu/pkgconfig/" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$(pwd)/dpdk-$DPDK_VERSION/install/lib/x86_64-linux-gnu/" >> $GITHUB_ENV
+          echo "DPDK_PATH=$(pwd)/dpdk-$DPDK_VERSION/install/" >> $GITHUB_ENV
+    - name: Retrive or compile DPDK
+      if: steps.cache-dpdk.outputs.cache-hit != 'true'
       run: |
             echo "Compiling DPDK..." ;
-            export STABLE=
-            export VERSION=20.11
-            export PKG_CONFIG_PATH=$(pwd)/dpdk-$STABLE$VERSION/install/lib/x86_64-linux-gnu/pkgconfig/ ;
-            export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$(pwd)/dpdk-$STABLE$VERSION/install/lib/x86_64-linux-gnu/ ;
-            export DPDK_PATH=$(pwd)/dpdk-$STABLE$VERSION/install/
-            if [ ! -e "dpdk-$STABLE$VERSION" ] || ! pkg-config --exists libdpdk ; then
-                wget http://fast.dpdk.org/rel/dpdk-$VERSION.tar.gz &&
-                tar -zxf dpdk-$VERSION.tar.gz &&
-                cd dpdk-$STABLE$VERSION &&
+            if [ ! -e "dpdk-$DPDK_VERSION" ] || ! pkg-config --exists libdpdk ; then
+                wget http://fast.dpdk.org/rel/dpdk-$DPDK_VERSION.tar.gz &&
+                tar -zxf dpdk-$DPDK_VERSION.tar.gz &&
+                cd dpdk-$DPDK_VERSION &&
                 pip3 install meson ninja &&
                 meson -Dprefix=$(pwd)/install/ build &&
                 cd build &&
@@ -55,9 +62,6 @@ jobs:
                 cd .. &&
                 cd .. ;
             fi
-            echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH" >> $GITHUB_ENV
-            echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH" >> $GITHUB_ENV
-            echo "DPDK_PATH=$DPDK_PATH" >> $GITHUB_ENV
 
     - name: Build Documentation (v0.1.0)
       run: git fetch --all --tags && git checkout v0.1.0 && cargo doc --lib --no-deps

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -24,7 +24,7 @@ sudo apt install build-essential meson pkg-config libnuma-dev python3-pyelftools
 ```
 
 ## Building and Installing DPDK
-Retina currently requires [**DPDK 20.11 or 21.08 or 23.11**](https://core.dpdk.org/download/). Note that 20.11 LTS has a bug that causes inaccurate packet drop metrics on some NICs.
+Retina currently requires [**DPDK 20.11 or 21.08 or 23.11 or 24.11**](https://core.dpdk.org/download/). Note that 20.11 LTS has a bug that causes inaccurate packet drop metrics on some NICs.
 
 ### System Configuration
 To get high performance from DPDK applications, we recommend the following system configuration steps. More details from the DPDK docs can be found [here](https://doc.dpdk.org/guides/linux_gsg/nic_perf_intel_platform.html).
@@ -63,16 +63,16 @@ sudo /etc/init.d/openibd restart
 This may update the firmware on your NIC, a reboot should complete the update if necessary.
 
 ### Install DPDK from source
-We recommend a local DPDK install from source. Download version 23.11 (or desired version) from the [DPDK downloads page](http://core.dpdk.org/download/):
+We recommend a local DPDK install from source. Download version 24.11 (or desired version) from the [DPDK downloads page](http://core.dpdk.org/download/):
 ```sh
-wget http://fast.dpdk.org/rel/dpdk-23.11.tar.xz
-tar xJf dpdk-23.11.tar.xz
+wget http://fast.dpdk.org/rel/dpdk-24.11.tar.xz
+tar xJf dpdk-24.11.tar.xz
 ```
 
 Set environment variables (For changing the version, set `DPDK_VERSION` properly):
 ```sh
-export DPDK_PATH=/path/to/dpdk/dpdk-23.11
-export DPDK_VERSION=23.11
+export DPDK_PATH=/path/to/dpdk/dpdk-24.11
+export DPDK_VERSION=24.11
 export LD_LIBRARY_PATH=$DPDK_PATH/lib/x86_64-linux-gnu
 export PKG_CONFIG_PATH=$LD_LIBRARY_PATH/pkgconfig
 ```

--- a/core/build.rs
+++ b/core/build.rs
@@ -18,9 +18,10 @@ fn main() {
     println!("cargo:rustc-check-cfg=cfg(dpdk_ge_2108)");
     println!("cargo:rustc-check-cfg=cfg(dpdk_ge_2111)");
     println!("cargo:rustc-check-cfg=cfg(dpdk_ge_2311)");
+    println!("cargo:rustc-check-cfg=cfg(dpdk_ge_2411)");
     let dpdk_version = env::var("DPDK_VERSION").expect("Set DPDK_VERSION env variable");
 
-    if !["20.11", "21.08", "23.11"].contains(&dpdk_version.as_str()) {
+    if !["20.11", "21.08", "23.11", "24.11"].contains(&dpdk_version.as_str()) {
         println!("Unsupported dpdk version");
         exit(1);
     }
@@ -32,6 +33,9 @@ fn main() {
             println!("cargo:rustc-cfg=dpdk_ge_2111");
             if dpdk_version != "21.11" {
                 println!("cargo:rustc-cfg=dpdk_ge_2311");
+                if dpdk_version != "23.11" {
+                    println!("cargo:rustc-cfg=dpdk_ge_2411");
+                }
             }
         }
     }

--- a/core/src/dpdk/mod.rs
+++ b/core/src/dpdk/mod.rs
@@ -33,6 +33,132 @@ impl rte_ipv4_hdr {
     }
 }
 
+#[cfg(not(dpdk_ge_2411))]
+impl rte_ipv6_hdr {
+    pub fn set_vtc_flow(&mut self, vtc_flow: u32) {
+        self.vtc_flow = vtc_flow;
+    }
+
+    pub fn set_src_addr(&mut self, src_addr: [u8; 16]) {
+        self.src_addr = src_addr;
+    }
+
+    pub fn set_dst_addr(&mut self, dst_addr: [u8; 16]) {
+        self.dst_addr = dst_addr;
+    }
+}
+
+#[cfg(dpdk_ge_2411)]
+impl rte_ipv6_hdr {
+    pub fn set_vtc_flow(&mut self, vtc_flow: u32) {
+        self.__bindgen_anon_1.vtc_flow = vtc_flow;
+    }
+
+    pub fn set_src_addr(&mut self, src_addr: [u8; 16]) {
+        self.src_addr = rte_ipv6_addr { a: src_addr };
+    }
+
+    pub fn set_dst_addr(&mut self, dst_addr: [u8; 16]) {
+        self.dst_addr = rte_ipv6_addr { a: dst_addr };
+    }
+}
+
+#[cfg(not(dpdk_ge_2411))]
+impl rte_mbuf {
+    pub fn get_buf_len(&self) -> usize {
+        unsafe { self.buf_len }.into()
+    }
+
+    pub fn get_data_len(&self) -> u16 {
+        unsafe { self.data_len }
+    }
+
+    pub fn get_pkt_len(&self) -> u32 {
+        unsafe { self.pkt_len }
+    }
+
+    pub fn get_data_off(&self) -> u16 {
+        unsafe { self.data_off }
+    }
+
+    pub fn get_rss_hash(&self) -> u32 {
+        unsafe { self.__bindgen_anon_2.hash.rss }
+    }
+
+    pub fn get_mark(&self) -> u32 {
+        unsafe { self.__bindgen_anon_2.hash.fdir.hi }
+    }
+
+    pub fn set_data_len(&mut self, data_len: u16) {
+        self.data_len = data_len
+    }
+
+    pub fn set_pkt_len(&mut self, pkt_len: u32) {
+        self.pkt_len = pkt_len
+    }
+
+    pub fn set_mark(&mut self, mark: u32) {
+        self.__bindgen_anon_2.hash.fdir.hi = mark
+    }
+}
+
+#[cfg(dpdk_ge_2411)]
+impl rte_mbuf {
+    pub fn get_buf_len(&self) -> usize {
+        unsafe { self.__bindgen_anon_2.__bindgen_anon_1.buf_len }.into()
+    }
+
+    pub fn get_data_len(&self) -> u16 {
+        unsafe { self.__bindgen_anon_2.__bindgen_anon_1.data_len }
+    }
+
+    pub fn get_pkt_len(&self) -> u32 {
+        unsafe { self.__bindgen_anon_2.__bindgen_anon_1.pkt_len }
+    }
+
+    pub fn get_data_off(&self) -> u16 {
+        unsafe { self.__bindgen_anon_1.__bindgen_anon_1.data_off }
+    }
+
+    pub fn get_rss_hash(&self) -> u32 {
+        unsafe {
+            self.__bindgen_anon_2
+                .__bindgen_anon_1
+                .__bindgen_anon_2
+                .hash
+                .rss
+        }
+    }
+
+    pub fn get_mark(&self) -> u32 {
+        unsafe {
+            self.__bindgen_anon_2
+                .__bindgen_anon_1
+                .__bindgen_anon_2
+                .hash
+                .fdir
+                .hi
+        }
+    }
+
+    pub fn set_data_len(&mut self, data_len: u16) {
+        self.__bindgen_anon_2.__bindgen_anon_1.data_len = data_len
+    }
+
+    pub fn set_pkt_len(&mut self, pkt_len: u32) {
+        self.__bindgen_anon_2.__bindgen_anon_1.pkt_len = pkt_len
+    }
+
+    pub fn set_mark(&mut self, mark: u32) {
+        self.__bindgen_anon_2
+            .__bindgen_anon_1
+            .__bindgen_anon_2
+            .hash
+            .fdir
+            .hi = mark
+    }
+}
+
 /*
  * DPDK v23.11 uses RTE_BIT64(x) macro to define RSS values, so we use
  * bindgen clang_macro_fallback to access them.

--- a/core/src/filter/hardware/flow_item.rs
+++ b/core/src/filter/hardware/flow_item.rs
@@ -223,8 +223,8 @@ impl FlowPattern {
                     "version_to_flow_label" => match value {
                         Value::Int(i) => {
                             if let Ok(val) = u32::try_from(*i) {
-                                ipv6_spec.hdr.vtc_flow = val.to_be();
-                                ipv6_mask.hdr.vtc_flow = u32::MAX;
+                                ipv6_spec.hdr.set_vtc_flow(val.to_be());
+                                ipv6_mask.hdr.set_vtc_flow(u32::MAX);
                             } else {
                                 bail!(FilterError::InvalidRhsValue(value.to_string()))
                             }
@@ -266,15 +266,23 @@ impl FlowPattern {
                     },
                     "src_addr" => match value {
                         Value::Ipv6(ipv6net) => {
-                            ipv6_spec.hdr.src_addr = u128::from(ipv6net.addr()).to_be_bytes();
-                            ipv6_mask.hdr.src_addr = u128::from(ipv6net.netmask()).to_be_bytes();
+                            ipv6_spec
+                                .hdr
+                                .set_src_addr(u128::from(ipv6net.addr()).to_be_bytes());
+                            ipv6_mask
+                                .hdr
+                                .set_src_addr(u128::from(ipv6net.netmask()).to_be_bytes());
                         }
                         _ => bail!(FilterError::InvalidRhsType(value.to_string())),
                     },
                     "dst_addr" => match value {
                         Value::Ipv6(ipv6net) => {
-                            ipv6_spec.hdr.dst_addr = u128::from(ipv6net.addr()).to_be_bytes();
-                            ipv6_mask.hdr.dst_addr = u128::from(ipv6net.netmask()).to_be_bytes();
+                            ipv6_spec
+                                .hdr
+                                .set_dst_addr(u128::from(ipv6net.addr()).to_be_bytes());
+                            ipv6_mask
+                                .hdr
+                                .set_dst_addr(u128::from(ipv6net.netmask()).to_be_bytes());
                         }
                         _ => bail!(FilterError::InvalidRhsType(value.to_string())),
                     },


### PR DESCRIPTION
This PR adds support for DPDK 24.11 while preserving the support for previous DPDK versions.

Changes included in this PR:
- Support for DPDK 24.11 was added.
- CI workflows have been updated to include checks for DPDK 24.11.
- CI workflows have been updated to cache DPDK build.