### PR TITLE
Use ThinLTO instead of FatLTO

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 resolver = "2"
 
 [profile.release]
-lto = true
+lto = "thin"
 
 [patch.crates-io]
 pcap = { git = 'https://github.com/thegwan/pcap', branch = 'compile-optimized' }


### PR DESCRIPTION
It reduces warm build time of the example basic from 40s to 16s on my machine.

I ran retina with three configs `fat` (which is equivalent to `true`), `thin` and `off`. I measured the idle cycle percentage (which is recommended by the dpdk documentation, since core usage percentage is always 100) using the prometheus query `avg(rate(retina_idle_cycles_total[5s])/rate(retina_all_cycles_total[5s]))` and there were significant difference between `off` and `thin`, but `thin` and `fat` were almost the same. So I concluded that fat lto doesn't have significant effect on performance and by using thin lto we can improve build time.