### PR TITLE
Upgrade toolchain's version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install Rust stable
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.81.0
+        toolchain: 1.84.0
         override: true
         components: rustfmt, clippy
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install Rust stable
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.81.0
+        toolchain: 1.84.0
         override: true
         components: rustfmt, clippy
     - name: Set up Python ${{ matrix.python-version }}

--- a/core/src/filter/hardware/mod.rs
+++ b/core/src/filter/hardware/mod.rs
@@ -93,7 +93,7 @@ impl<'a> HardwareFilter<'a> {
     }
 }
 
-impl<'a> fmt::Display for HardwareFilter<'a> {
+impl fmt::Display for HardwareFilter<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         writeln!(f, "[HardwareFilter]: ")?;
         for pattern in self.patterns.iter() {

--- a/core/src/memory/mempool.rs
+++ b/core/src/memory/mempool.rs
@@ -89,7 +89,7 @@ impl fmt::Debug for Mempool {
 
 /// Rounds `n` up to the nearest multiple of `s`
 fn round_up(n: u32, s: u32) -> u32 {
-    ((n + s - 1) / s) * s
+    n.div_ceil(s) * s
 }
 
 #[derive(Error, Debug)]

--- a/core/src/protocols/packet/ethernet.rs
+++ b/core/src/protocols/packet/ethernet.rs
@@ -29,7 +29,7 @@ pub struct Ethernet<'a> {
     mbuf: &'a Mbuf,
 }
 
-impl<'a> Ethernet<'a> {
+impl Ethernet<'_> {
     /// Returns the destination MAC address.
     #[inline]
     pub fn dst(&self) -> MacAddr {

--- a/core/src/protocols/packet/ipv4.rs
+++ b/core/src/protocols/packet/ipv4.rs
@@ -32,7 +32,7 @@ pub struct Ipv4<'a> {
     mbuf: &'a Mbuf,
 }
 
-impl<'a> Ipv4<'a> {
+impl Ipv4<'_> {
     /// Returns the IP protocol version.
     #[inline]
     pub fn version(&self) -> u8 {

--- a/core/src/protocols/packet/ipv6.rs
+++ b/core/src/protocols/packet/ipv6.rs
@@ -24,7 +24,7 @@ pub struct Ipv6<'a> {
     mbuf: &'a Mbuf,
 }
 
-impl<'a> Ipv6<'a> {
+impl Ipv6<'_> {
     /// Returns the IP protocol version.
     #[inline]
     pub fn version(&self) -> u8 {

--- a/core/src/protocols/packet/tcp.rs
+++ b/core/src/protocols/packet/tcp.rs
@@ -32,7 +32,7 @@ pub struct Tcp<'a> {
     mbuf: &'a Mbuf,
 }
 
-impl<'a> Tcp<'a> {
+impl Tcp<'_> {
     /// Returns the sending port.
     #[inline]
     pub fn src_port(&self) -> u16 {

--- a/core/src/protocols/packet/udp.rs
+++ b/core/src/protocols/packet/udp.rs
@@ -21,7 +21,7 @@ pub struct Udp<'a> {
     mbuf: &'a Mbuf,
 }
 
-impl<'a> Udp<'a> {
+impl Udp<'_> {
     /// Returns the sending port.
     #[inline]
     pub fn src_port(&self) -> u16 {

--- a/core/src/subscription/mod.rs
+++ b/core/src/subscription/mod.rs
@@ -147,7 +147,6 @@ where
     }
 
     /// Delivery functions, including delivery to the correct callback
-
     pub fn deliver_packet(&self, mbuf: &Mbuf, conn_data: &ConnData, tracked: &S::Tracked) {
         (self.packet_deliver)(mbuf, conn_data, tracked)
     }

--- a/datatypes/src/conn_fts.rs
+++ b/datatypes/src/conn_fts.rs
@@ -187,7 +187,7 @@ impl Tracked for InterArrivals {
 }
 
 struct DurationVec<'a>(&'a Vec<Duration>);
-impl<'a> Serialize for DurationVec<'a> {
+impl Serialize for DurationVec<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,

--- a/datatypes/src/typedefs.rs
+++ b/datatypes/src/typedefs.rs
@@ -117,7 +117,7 @@ pub type SessionList = Vec<Session>;
 /// The string literal representing a matched filter.
 pub type FilterStr<'a> = &'a str;
 
-impl<'a> FromSubscription for FilterStr<'a> {
+impl FromSubscription for FilterStr<'_> {
     fn from_subscription(spec: &SubscriptionSpec) -> proc_macro2::TokenStream {
         let str = syn::LitStr::new(&spec.filter, Span::call_site());
         quote! { &#str }


### PR DESCRIPTION
This PR adds upgrades toolchain's version to 1.84.0.

Changes included in this PR:
- Toolchain's version has been upgraded to 1.84.0.
- Code style has been formatted in accordance with clippy guidelines.