### PR TITLE
Don't call `Instant::now()` on each iteration

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -16,7 +16,6 @@ byteorder = "1.4.3"
 chrono = "0.4"
 colored = "2"
 cpu-time = "1.0.0"
-crossbeam-channel = "0.5.8"
 csv = "1.2.1"
 ctrlc = { version = "3.2.5", features = ["termination"] }
 dns-parser = { git = "https://github.com/stanford-esrg/dns-parser" }

--- a/core/src/conntrack/mod.rs
+++ b/core/src/conntrack/mod.rs
@@ -177,9 +177,13 @@ where
     }
 
     /// Checks for and removes inactive connections.
-    pub(crate) fn check_inactive(&mut self, subscription: &Subscription<T::Subscribed>) {
+    pub(crate) fn check_inactive(
+        &mut self,
+        subscription: &Subscription<T::Subscribed>,
+        now: Instant,
+    ) {
         self.timerwheel
-            .check_inactive(&mut self.table, subscription);
+            .check_inactive(&mut self.table, subscription, now);
     }
 }
 

--- a/core/src/lcore/rx_core.rs
+++ b/core/src/lcore/rx_core.rs
@@ -103,17 +103,17 @@ where
                 let mbufs: Vec<Mbuf> = self.rx_burst(rxqueue, 32);
                 if mbufs.is_empty() {
                     IDLE_CYCLES.inc();
-
-                    if IDLE_CYCLES.get() & 1023 == 512 {
-                        now = Instant::now();
-                    }
-
-                    #[cfg(feature = "prometheus")]
-                    if IDLE_CYCLES.get() & 1023 == 0 && self.is_prometheus_enabled {
-                        crate::stats::update_thread_local_stats(self.id);
-                    }
                 }
+
                 TOTAL_CYCLES.inc();
+                if TOTAL_CYCLES.get() & 1023 == 512 {
+                    now = Instant::now();
+                }
+                #[cfg(feature = "prometheus")]
+                if TOTAL_CYCLES.get() & 1023 == 0 && self.is_prometheus_enabled {
+                    crate::stats::update_thread_local_stats(self.id);
+                }
+
                 for mbuf in mbufs.into_iter() {
                     // log::debug!("{:#?}", mbuf);
                     // log::debug!("Mark: {}", mbuf.mark());

--- a/core/src/lcore/rx_core.rs
+++ b/core/src/lcore/rx_core.rs
@@ -12,6 +12,7 @@ use crate::subscription::*;
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::time::Instant;
 
 use itertools::Itertools;
 
@@ -95,11 +96,17 @@ where
         log::debug!("{:#?}", registry);
         let mut conn_table = ConnTracker::<S::Tracked>::new(config, registry, self.id);
 
+        let mut now = Instant::now();
+
         while self.is_running.load(Ordering::Relaxed) {
             for rxqueue in self.rxqueues.iter() {
                 let mbufs: Vec<Mbuf> = self.rx_burst(rxqueue, 32);
                 if mbufs.is_empty() {
                     IDLE_CYCLES.inc();
+
+                    if IDLE_CYCLES.get() & 1023 == 512 {
+                        now = Instant::now();
+                    }
 
                     #[cfg(feature = "prometheus")]
                     if IDLE_CYCLES.get() & 1023 == 0 && self.is_prometheus_enabled {
@@ -133,7 +140,7 @@ where
                     }
                 }
             }
-            conn_table.check_inactive(&self.subscription);
+            conn_table.check_inactive(&self.subscription, now);
         }
 
         // // Deliver remaining data in table from unfinished connections


### PR DESCRIPTION
Previously, timerwheel used `crossbeam_channel::tick::try_recv` function. This function called `Instant::now` to see if it should emit an `Instant`. Calling `Instant::now` requires a syscall and it is not fast enough to be called on each iteration. This PR uses a `now` variable that is occasionally updated, and uses it instead of `crossbeam_channel`. I also replaced the other usage of it with `tokio` and removed the `crossbeam_channel` dependency entirely.

My vtune says this function consumes 20% of the cpu. Its usage is mostly in idle cycles but it is not free in busy cycles. I will try to measure its effect later.