### PR TITLE
Add back the byte regex operator as a binary operator in the grammar

### DIFF
--- a/core/src/filter/grammar.pest
+++ b/core/src/filter/grammar.pest
@@ -53,7 +53,7 @@ not_op = { "!" | "not" | "NOT" }  // not yet supported, temp placeholder
 // Binary operators
 // ----------------------------------------------------------------------
 bin_op = {
-    eq_op | ne_op | ge_op | le_op | gt_op | lt_op | in_op | re_op | en_op | contains_op | re_op 
+    eq_op | ne_op | ge_op | le_op | gt_op | lt_op | in_op | byte_re_op | re_op | en_op | contains_op
 }
 
 eq_op = { "=" }


### PR DESCRIPTION
This PR fixes a minor issue where `byte_re_op` was removed from `bin_op` in the grammar while resolving some merge conflicts.