### PR TITLE
Not equals for strings and bytes

### DIFF
--- a/filtergen/src/utils.rs
+++ b/filtergen/src/utils.rs
@@ -201,7 +201,7 @@ pub(crate) fn binary_to_tokens(
             BinOp::Ne => {
                 let bytes_lit = syn::LitByteStr::new(b, Span::call_site());
                 quote! {
-                    #proto.#field().as_ref() != #bytes_lit
+                    (#proto.#field().as_ref() as &[u8]) != #bytes_lit
                 }
             }
             BinOp::Contains => {

--- a/filtergen/src/utils.rs
+++ b/filtergen/src/utils.rs
@@ -201,7 +201,7 @@ pub(crate) fn binary_to_tokens(
             BinOp::Ne => {
                 let bytes_lit = syn::LitByteStr::new(b, Span::call_site());
                 quote! {
-                    (#proto.#field().as_ref() as &[u8]) != #bytes_lit
+                    #proto.#field().as_ref() as &[u8] != #bytes_lit
                 }
             }
             BinOp::Contains => {

--- a/filtergen/src/utils.rs
+++ b/filtergen/src/utils.rs
@@ -125,6 +125,10 @@ pub(crate) fn binary_to_tokens(
                     let val_lit = syn::LitStr::new(text, Span::call_site());
                     quote! { #proto.#field() == #val_lit }
                 }
+                BinOp::Ne => {
+                    let val_lit = syn::LitStr::new(text, Span::call_site());
+                    quote! { #proto.#field() != #val_lit }
+                }
                 BinOp::En => {
                     let field_ident =
                         Ident::new(&field.to_string().to_camel_case(), Span::call_site());
@@ -192,6 +196,12 @@ pub(crate) fn binary_to_tokens(
                 let bytes_lit = syn::LitByteStr::new(b, Span::call_site());
                 quote! {
                     #proto.#field().as_bytes() == #bytes_lit
+                }
+            }
+            BinOp::Ne => {
+                let bytes_lit = syn::LitByteStr::new(b, Span::call_site());
+                quote! {
+                    #proto.#field().as_ref() != #bytes_lit
                 }
             }
             BinOp::Contains => {


### PR DESCRIPTION
This PR implements support for the not equals operator (`!=`) to be used with strings and bytes. When used with bytes, the value on the LHS of the operator could be of type string or byte.