### PR TITLE
Fix equals operator for byte values

### DIFF
--- a/filtergen/src/lib.rs
+++ b/filtergen/src/lib.rs
@@ -138,7 +138,7 @@
 //! | Integer       | `443`              |
 //! | String        | `'Safari'`         |
 //! | Integer range | `1024..5000`       |
-//! | Byte          | `|32 2E 30|`       |
+//! | Byte          | `\|32 2E 30\|`       |
 //!
 //! ## Binary comparison operators
 //! | Operator |   Alias   |         Description        | Example                         |

--- a/filtergen/src/utils.rs
+++ b/filtergen/src/utils.rs
@@ -191,7 +191,7 @@ pub(crate) fn binary_to_tokens(
             BinOp::Eq => {
                 let bytes_lit = syn::LitByteStr::new(b, Span::call_site());
                 quote! {
-                    #proto.#field().as_bytes() == #bytes_lit
+                    &(#proto.#field().as_bytes()).as_ref() == #bytes_lit
                 }
             }
             BinOp::Contains => {

--- a/filtergen/src/utils.rs
+++ b/filtergen/src/utils.rs
@@ -191,7 +191,7 @@ pub(crate) fn binary_to_tokens(
             BinOp::Eq => {
                 let bytes_lit = syn::LitByteStr::new(b, Span::call_site());
                 quote! {
-                    &(#proto.#field().as_bytes()).as_ref() == #bytes_lit
+                    #proto.#field().as_ref() as &[u8] == #bytes_lit
                 }
             }
             BinOp::Contains => {


### PR DESCRIPTION
This PR makes 2 fixes related to using the equality operator (`=`) with bytes:
1. The LHS of the operator could be of type string or byte. If it's a string, convert it to bytes.
2. Escape pipes in the docs (otherwise the pipes get treated as being part of the table)