### PR TITLE
not contains operator

### DIFF
--- a/core/src/filter/ast.rs
+++ b/core/src/filter/ast.rs
@@ -762,7 +762,7 @@ pub(super) fn is_excl_int(
             BinOp::In => return peer_to < from || peer_from > to,
             _ => {}
         },
-        BinOp::Re | BinOp::En | BinOp::Contains | BinOp::ByteRe => {}
+        BinOp::Re | BinOp::En | BinOp::Contains | BinOp::ByteRe | BinOp::NotContains => {}
     }
     false
 }
@@ -899,6 +899,7 @@ pub enum BinOp {
     En,
     ByteRe,
     Contains,
+    NotContains,
 }
 
 impl fmt::Display for BinOp {
@@ -915,6 +916,7 @@ impl fmt::Display for BinOp {
             BinOp::En => write!(f, "eq"),
             BinOp::ByteRe => write!(f, "~b"),
             BinOp::Contains => write!(f, "contains"),
+            BinOp::NotContains => write!(f, "!contains"),
         }
     }
 }

--- a/core/src/filter/ast.rs
+++ b/core/src/filter/ast.rs
@@ -916,7 +916,7 @@ impl fmt::Display for BinOp {
             BinOp::En => write!(f, "eq"),
             BinOp::ByteRe => write!(f, "~b"),
             BinOp::Contains => write!(f, "contains"),
-            BinOp::NotContains => write!(f, "!contains"),
+            BinOp::NotContains => write!(f, "not contains"),
         }
     }
 }

--- a/core/src/filter/grammar.pest
+++ b/core/src/filter/grammar.pest
@@ -67,7 +67,7 @@ re_op = { "~" | "matches" }
 en_op = { "eq" }
 byte_re_op = { "~b" }
 contains_op = { "contains" }
-not_contains_op = { "!contains" }
+not_contains_op = { "!contains" | "not contains" }
 
 // Miscellaneous
 // ----------------------------------------------------------------------

--- a/core/src/filter/grammar.pest
+++ b/core/src/filter/grammar.pest
@@ -53,7 +53,7 @@ not_op = { "!" | "not" | "NOT" }  // not yet supported, temp placeholder
 // Binary operators
 // ----------------------------------------------------------------------
 bin_op = {
-    eq_op | ne_op | ge_op | le_op | gt_op | lt_op | in_op | byte_re_op | re_op | en_op | contains_op
+    eq_op | ne_op | ge_op | le_op | gt_op | lt_op | in_op | byte_re_op | re_op | en_op | contains_op | not_contains_op
 }
 
 eq_op = { "=" }
@@ -67,6 +67,7 @@ re_op = { "~" | "matches" }
 en_op = { "eq" }
 byte_re_op = { "~b" }
 contains_op = { "contains" }
+not_contains_op = { "!contains" }
 
 // Miscellaneous
 // ----------------------------------------------------------------------

--- a/core/src/filter/parser.rs
+++ b/core/src/filter/parser.rs
@@ -185,6 +185,7 @@ impl FilterParser {
             Rule::en_op => Ok(BinOp::En),
             Rule::byte_re_op => Ok(BinOp::ByteRe),
             Rule::contains_op => Ok(BinOp::Contains),
+            Rule::not_contains_op => Ok(BinOp::NotContains),
             _ => bail!(FilterError::InvalidBinOp(op_str)),
         }
     }

--- a/examples/log_ssh/src/main.rs
+++ b/examples/log_ssh/src/main.rs
@@ -46,7 +46,7 @@ fn ssh_contains_bytes_cb(ssh: &SshHandshake) {
     }
 }
 
-#[filter("ssh.software_version_ctos contains 'OpenSSH'")]
+#[filter("ssh.software_version_ctos not contains 'OpenSSH'")]
 fn ssh_contains_str_cb(ssh: &SshHandshake) {
     if let Ok(serialized) = serde_json::to_string(&ssh) {
         let mut wtr = file.lock().unwrap();

--- a/filtergen/src/lib.rs
+++ b/filtergen/src/lib.rs
@@ -153,7 +153,7 @@
 //! | `~`      | `matches` | Regular expression match   | `tls.sni ~ 'netflix\\.com$'`    |
 //! | `~b`     |           | Byte regular expression match | `ssh.protocol_version_ctos ~b '(?-u)^\x32\\.\x30$'` |
 //! | `contains` |           | Check if right appears in left | `ssh.key_exchange_cookie_stoc contains \|15 A1\|` |
-//! | `not contains` | `!contains` | Check if right doesn't appear in left | `ssh.key_exchange_cookie_stoc not contains \|15 A1\|` |
+//! | `not contains` | `!contains` | Check that right doesn't appear in left | `ssh.key_exchange_cookie_stoc not contains \|15 A1\|` |
 //!
 //! **Possible pitfalls involving `!=`**
 //!

--- a/filtergen/src/lib.rs
+++ b/filtergen/src/lib.rs
@@ -153,6 +153,7 @@
 //! | `~`      | `matches` | Regular expression match   | `tls.sni ~ 'netflix\\.com$'`    |
 //! | `~b`     |           | Byte regular expression match | `ssh.protocol_version_ctos ~b '(?-u)^\x32\\.\x30$'` |
 //! | `contains` |           | Check if right appears in left | `ssh.key_exchange_cookie_stoc contains \|15 A1\|` |
+//! | `not contains` | `!contains` | Check if right doesn't appear in left | `ssh.key_exchange_cookie_stoc not contains \|15 A1\|` |
 //!
 //! **Possible pitfalls involving `!=`**
 //!

--- a/filtergen/src/utils.rs
+++ b/filtergen/src/utils.rs
@@ -188,6 +188,19 @@ pub(crate) fn binary_to_tokens(
                         #finder_ident.find(#proto.#field().as_bytes()).is_some()
                     }
                 }
+                BinOp::NotContains => {
+                    let val_lit = syn::LitStr::new(text, Span::call_site());
+
+                    let finder_name = format!("FINDER{}", statics.len());
+                    let finder_ident = Ident::new(&finder_name, Span::call_site());
+                    let lazy_finder = quote! {
+                        static ref #finder_ident: memchr::memmem::Finder<'static> = memchr::memmem::Finder::new(#val_lit.as_bytes());
+                    };
+                    statics.push(lazy_finder);
+                    quote! {
+                        #finder_ident.find(#proto.#field().as_bytes()).is_none()
+                    }
+                }
                 _ => panic!("Invalid binary operation `{}` for value: `{}`.", op, value),
             }
         }
@@ -215,6 +228,19 @@ pub(crate) fn binary_to_tokens(
                 statics.push(lazy_finder);
                 quote! {
                     #finder_ident.find(#proto.#field().as_ref()).is_some()
+                }
+            }
+            BinOp::NotContains => {
+                let bytes_lit = syn::LitByteStr::new(b, Span::call_site());
+
+                let finder_name = format!("FINDER{}", statics.len());
+                let finder_ident = Ident::new(&finder_name, Span::call_site());
+                let lazy_finder = quote! {
+                    static ref #finder_ident: memchr::memmem::Finder<'static> = memchr::memmem::Finder::new(#bytes_lit);
+                };
+                statics.push(lazy_finder);
+                quote! {
+                    #finder_ident.find(#proto.#field().as_ref()).is_none()
                 }
             }
             _ => panic!("Invalid binary operation `{}` for value: `{}`.", op, value),


### PR DESCRIPTION
This PR adds a new binary operator, not contains, which can be used with strings or bytes. 