### PR TITLE
Initial Streaming Callbacks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "examples/basic",
     "examples/basic_file",
     "examples/log_ssh",
+    "examples/streaming",
 ]
 resolver = "2"
 

--- a/core/src/filter/actions.rs
+++ b/core/src/filter/actions.rs
@@ -56,6 +56,9 @@ pub enum ActionData {
 
     /// Deliver connection data (via the ConnectionDelivery filter) when it terminates
     ConnDeliver,
+
+    /// Invoke any active streaming callbacks.
+    Stream,
 }
 
 /// Actions maintained per-connection
@@ -127,6 +130,16 @@ impl Actions {
     /// True if the connection needs to be reassembled
     pub(crate) fn reassemble(&self) -> bool {
         self.data.intersects(ActionData::Reassemble) || self.parse_any()
+    }
+
+    /// True if streaming callbacks are available to be invoked
+    pub(crate) fn stream_deliver(&self) -> bool {
+        self.data.intersects(ActionData::Stream)
+    }
+
+    pub fn clear_stream_cbs(&mut self) {
+        self.data &= ActionData::Stream.not();
+        self.terminal_actions &= ActionData::Stream.not();
     }
 
     /// True if the framework should buffer mbufs for this connection,

--- a/core/src/filter/datatypes.rs
+++ b/core/src/filter/datatypes.rs
@@ -3,6 +3,7 @@
 use super::ast::Predicate;
 use super::ptree::FilterLayer;
 use super::{ActionData, Actions};
+use serde::{Deserialize, Serialize};
 
 /// The abstraction levels for subscribable datatypes
 /// These essentially dictate at what point a datatype can/should be delivered
@@ -23,6 +24,59 @@ pub enum Level {
     /// Static-only subscriptions are delivered either on first packet
     /// (if possible) or at connection termination (otherwise).
     Static,
+    /// Applicable only to subscriptions. Indicates that the associated
+    /// callback is one for which data will be delivered in a streaming capacity.
+    Streaming(Streaming),
+}
+
+impl Level {
+    /// Whether a datatype at this Level can be delivered
+    /// in a streaming callback.
+    pub fn can_stream(&self) -> bool {
+        matches!(self, Level::Connection)
+    }
+}
+
+/// Associated data for streaming callbacks.
+#[derive(Clone, Debug, Copy, Serialize, Deserialize)]
+pub enum Streaming {
+    Seconds(f32),
+    Packets(u32),
+    Bytes(u32),
+    // TODO - PayloadBytes (in packets, L4, L6/L7), PayloadPackets, reassembled...
+}
+
+impl From<(&str, f32)> for Streaming {
+    fn from(inp: (&str, f32)) -> Self {
+        match inp.0.to_lowercase().as_str() {
+            "seconds" => Streaming::Seconds(inp.1),
+            "packets" => Streaming::Packets(inp.1 as u32),
+            "bytes" => Streaming::Bytes(inp.1 as u32),
+            _ => panic!("Unknown Streaming variant: {}", inp.0),
+        }
+    }
+}
+
+use proc_macro2::Span;
+use quote::{quote, ToTokens};
+
+impl ToTokens for Streaming {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        tokens.extend(match self {
+            Streaming::Seconds(val) => {
+                let val = syn::LitFloat::new(&val.to_string(), Span::call_site());
+                quote! { Streaming::Seconds(#val as f32) }
+            }
+            Streaming::Packets(val) => {
+                let val = syn::LitInt::new(&val.to_string(), Span::call_site());
+                quote! { Streaming::Packets(#val) }
+            }
+            Streaming::Bytes(val) => {
+                let val = syn::LitInt::new(&val.to_string(), Span::call_site());
+                quote! { Streaming::Bytes(#val) }
+            }
+        })
+    }
 }
 
 /// Specification for one complete subscription
@@ -183,6 +237,7 @@ impl DataType {
                 // Since protocol/session filter could be >1x/connection, can't
                 // deliver in those filters.
             }
+            Level::Streaming(_) => panic!("Datatypes should not be streaming"),
         }
     }
 
@@ -205,6 +260,7 @@ impl DataType {
                 )
             }
             Level::Static => true,
+            Level::Streaming(_) => panic!("Datatypes should not be streaming"),
         }
     }
 
@@ -232,7 +288,7 @@ impl DataType {
         // SessionTrack should only be terminal if matched at packet layer
         // After parsing is complete, session will be tracked if it matched
         // at any layer. See "on_parse" in conntrack mod.
-        if matches!(sub_level, Level::Connection)
+        if (matches!(sub_level, Level::Connection) || matches!(sub_level, Level::Streaming(_)))
             && (matches!(self.level, Level::Session) || self.needs_parse)
         {
             actions.if_matched.data |= ActionData::SessionTrack;
@@ -259,7 +315,6 @@ impl DataType {
             // Matched packet-level subscription is delivered in filter
         }
 
-        // Connection- and session-level subscriptions depend on the actions required
         self.needs_update(&mut actions);
         self.conn_deliver(sub_level, &mut actions);
 
@@ -278,8 +333,10 @@ impl DataType {
             // due to Protocol Filter being applied.
         }
 
-        // Session-level datatype can be delivered when session is parsed
-        if matches!(self.level, Level::Session) {
+        // Session-level subscription can be delivered when session is parsed
+        if matches!(self.level, Level::Session)
+            && matches!(sub_level, Level::Session | Level::Streaming(_))
+        {
             actions.if_matched.data |= ActionData::SessionDeliver;
             actions.if_matched.terminal_actions |= ActionData::SessionDeliver;
         }
@@ -299,12 +356,13 @@ impl DataType {
             actions.if_matching.data |= ActionData::PacketCache;
         }
 
-        // Connection- and session-level subscriptions depend on the actions required
         self.needs_update(&mut actions);
         self.track_sessions(&mut actions, sub_level);
         self.conn_deliver(sub_level, &mut actions);
 
-        if matches!(sub_level, Level::Session) {
+        if matches!(self.level, Level::Session)
+            && matches!(sub_level, Level::Session | Level::Streaming(_))
+        {
             // Deliver session when parsed (done in session filter)
             actions.if_matched.data |= ActionData::SessionDeliver;
         }
@@ -420,6 +478,18 @@ impl SubscriptionSpec {
             );
         }
 
+        if matches!(self.level, Level::Streaming(_)) {
+            assert!(
+                self.datatypes
+                    .iter()
+                    .filter(|d| d.level.can_stream())
+                    .count()
+                    == 1,
+                "Must have one streamable datatype in streaming subscription: {:?}",
+                self
+            ) // TODO should be able to have multiple streaming datatypes.
+        }
+
         assert!(
             self.datatypes
                 .iter()
@@ -433,7 +503,9 @@ impl SubscriptionSpec {
 
     // Add a new datatype to the subscription
     pub fn add_datatype(&mut self, datatype: DataType) {
-        self.update_level(&datatype.level);
+        if !matches!(self.level, Level::Streaming(_) | Level::Connection) {
+            self.update_level(&datatype.level);
+        }
         self.datatypes.push(datatype);
     }
 
@@ -466,6 +538,15 @@ impl SubscriptionSpec {
         spec
     }
 
+    #[allow(dead_code)]
+    pub(crate) fn new_default_streaming() -> Self {
+        let mut spec = Self::new(String::from("fil"), String::from("cb"));
+        spec.level = Level::Streaming(Streaming::Seconds(10.0));
+        spec.datatypes
+            .push(DataType::new_default_connection("Connection"));
+        spec
+    }
+
     // Format subscription as "callback(datatypes)"
     pub fn as_str(&self) -> String {
         let datatype_str: Vec<&'static str> = self.datatypes.iter().map(|d| d.as_str).collect();
@@ -475,13 +556,53 @@ impl SubscriptionSpec {
     // Should this subscription be delivered if the filter matched
     // This should return true for the first filter at which all datatypes can be delivered
     pub(crate) fn should_deliver(&self, filter_layer: FilterLayer, pred: &Predicate) -> bool {
-        self.datatypes
-            .iter()
-            .any(|d| d.should_deliver(&filter_layer, pred, &self.level))
+        !matches!(self.level, Level::Streaming(_))
+            && self
+                .datatypes
+                .iter()
+                .any(|d| d.should_deliver(&filter_layer, pred, &self.level))
             && self
                 .datatypes
                 .iter()
                 .all(|d| d.can_deliver(&filter_layer, pred))
+    }
+
+    // Helpers
+    pub(crate) fn deliver_on_session(&self) -> bool {
+        matches!(self.level, Level::Session)
+            || (matches!(self.level, Level::Streaming(_))
+                && self
+                    .datatypes
+                    .iter()
+                    .any(|d| matches!(d.level, Level::Session)))
+    }
+
+    pub(crate) fn should_stream(&self, filter_layer: FilterLayer, pred: &Predicate) -> bool {
+        if !matches!(self.level, Level::Streaming(_)) {
+            return false;
+        }
+        // Eliminate if some datatype isn't ready to be delivered
+        if self
+            .datatypes
+            .iter()
+            .any(|d| !d.can_deliver(&filter_layer, pred) && !d.level.can_stream())
+        {
+            return false;
+        }
+        // Case 1: streaming datatypes only
+        // Deliver as soon as predicates match
+        if self
+            .datatypes
+            .iter()
+            .all(|d| d.level.can_stream() || matches!(d.level, Level::Static))
+        {
+            return !pred.is_prev_layer(filter_layer, self);
+        }
+        // Case 2: some non-streaming datatype
+        // Deliver as soon as it's ready
+        self.datatypes
+            .iter()
+            .any(|d| d.should_deliver(&filter_layer, pred, &self.level))
     }
 
     // Actions for the PacketContinue filter stage
@@ -514,6 +635,10 @@ impl SubscriptionSpec {
             actions.push(&datatype.packet_filter(&self.level));
         }
         actions.if_matching.data |= ActionData::ProtoFilter;
+        if matches!(self.level, Level::Streaming(_)) {
+            actions.if_matched.data |= ActionData::Stream;
+            actions.if_matched.terminal_actions |= ActionData::Stream;
+        }
         actions
     }
 
@@ -526,6 +651,10 @@ impl SubscriptionSpec {
         if matches!(self.level, Level::Static) {
             actions.if_matched.data |= ActionData::ConnDeliver;
             actions.if_matched.terminal_actions |= ActionData::ConnDeliver;
+        }
+        if matches!(self.level, Level::Streaming(_)) {
+            actions.if_matched.data |= ActionData::Stream;
+            actions.if_matched.terminal_actions |= ActionData::Stream;
         }
         actions.if_matching.data |= ActionData::SessionFilter;
         actions
@@ -540,6 +669,10 @@ impl SubscriptionSpec {
         if matches!(self.level, Level::Static) {
             actions.if_matched.data |= ActionData::ConnDeliver;
             actions.if_matched.terminal_actions |= ActionData::ConnDeliver;
+        }
+        if matches!(self.level, Level::Streaming(_)) {
+            actions.if_matched.data |= ActionData::Stream;
+            actions.if_matched.terminal_actions |= ActionData::Stream;
         }
         actions
     }
@@ -605,5 +738,10 @@ mod tests {
         spec.add_datatype(DataType::new_default_packet("Packet"));
         assert!(spec.proto_filter().if_matched.packet_deliver());
         assert!(spec.proto_filter().if_matching.cache_packet());
+
+        let mut spec = SubscriptionSpec::new_default_streaming();
+        spec.add_datatype(DataType::new_default_session("Session", vec![]));
+        assert!(matches!(spec.level, Level::Streaming(_)));
+        assert!(spec.proto_filter().if_matched.stream_deliver());
     }
 }

--- a/core/src/filter/datatypes.rs
+++ b/core/src/filter/datatypes.rs
@@ -108,7 +108,7 @@ pub struct DataType {
     pub track_sessions: bool,
     /// True if the datatype requires invoking `update` method before reassembly
     pub needs_update: bool,
-    /// True if the datatype requires reassembly (for `track_packets` or `update`)
+    /// True if the datatype requires reassembly (for `update`)
     pub needs_reassembly: bool,
     /// True if the datatype requires tracking packets
     pub needs_packet_track: bool,

--- a/core/src/filter/hardware/mod.rs
+++ b/core/src/filter/hardware/mod.rs
@@ -363,10 +363,7 @@ fn add_redirect(port: &Port, from_group: u32, to_group: u32, priority: u32) -> R
         );
         if ret != 0 {
             let msg: &CStr = CStr::from_ptr(error.message);
-            error!(
-                "Redirect rule failed validation: {}",
-                msg.to_str().unwrap().to_string()
-            );
+            error!("Redirect rule failed validation: {}", msg.to_str().unwrap());
             bail!(HardwareFilterError::Validation {
                 lpattern: LayeredPattern::new(),
                 reason: msg.to_str().unwrap().to_string()

--- a/core/src/filter/mod.rs
+++ b/core/src/filter/mod.rs
@@ -48,16 +48,16 @@ use thiserror::Error;
 /// the framework will additionally attempt to install the filter in the NICs.
 pub type PacketContFn = fn(&Mbuf, &CoreId) -> Actions;
 /// Filter applied to the first packet of a connection to initialize actions.
-pub type PacketFilterFn<T> = fn(&Mbuf, &T) -> Actions;
+pub type PacketFilterFn<T> = fn(&Mbuf, &mut T) -> Actions;
 /// Filter applied when the application-layer protocol is identified.
 /// This may drop connections or update actions.
 /// It may also drain buffered packets to packet-level subscriptions that match
 /// at the protocol stage.
-pub type ProtoFilterFn<T> = fn(&ConnData, &T) -> Actions;
+pub type ProtoFilterFn<T> = fn(&ConnData, &mut T) -> Actions;
 /// Filter applied when the application-layer session is parsed.
 /// This may drop connections, drop sessions, or update actions.
 /// It may also deliver session-level subscriptions.
-pub type SessionFilterFn<T> = fn(&Session, &ConnData, &T) -> Actions;
+pub type SessionFilterFn<T> = fn(&Session, &ConnData, &mut T) -> Actions;
 /// Filter applied to disambiguate and deliver matched packet-level subscriptions
 /// that required stateful filtering (i.e., could not be delivered at the packet stage).
 pub type PacketDeliverFn<T> = fn(&Mbuf, &ConnData, &T);

--- a/core/src/filter/pattern.rs
+++ b/core/src/filter/pattern.rs
@@ -1,6 +1,5 @@
-use super::ast::*;
-use super::datatypes::Level;
 use super::ptree::FilterLayer;
+use super::{ast::*, SubscriptionSpec};
 
 use std::cmp::Ordering;
 use std::collections::HashSet;
@@ -54,11 +53,11 @@ impl FlatPattern {
     pub(super) fn is_prev_layer(
         &self,
         filter_layer: FilterLayer,
-        subscription_level: &Level,
+        subscription: &SubscriptionSpec,
     ) -> bool {
         self.predicates
             .iter()
-            .all(|p| p.is_prev_layer(filter_layer, subscription_level))
+            .all(|p| p.is_prev_layer(filter_layer, subscription))
     }
 
     // Returns a vector of fully qualified patterns from self

--- a/core/src/subscription/mod.rs
+++ b/core/src/subscription/mod.rs
@@ -41,6 +41,9 @@ pub trait Trackable {
     /// Can help free mbufs for future use
     fn drain_tracked_packets(&mut self);
 
+    /// Check and potentially deliver to streaming callbacks
+    fn stream_deliver(&mut self, actions: &mut Actions, pdu: &L4Pdu);
+
     /// Drain data from packets cached for future potential delivery
     /// Used after these packets have been delivered or when associated
     /// subscription fails to match
@@ -125,13 +128,13 @@ where
 
     /// Invokes the five-tuple filter.
     /// Applied to the first packet in the connection.
-    pub fn filter_packet(&self, mbuf: &Mbuf, tracked: &S::Tracked) -> Actions {
+    pub fn filter_packet(&self, mbuf: &Mbuf, tracked: &mut S::Tracked) -> Actions {
         (self.packet_filter)(mbuf, tracked)
     }
 
     /// Invokes the end-to-end protocol filter.
     /// Applied once a parser identifies the application-layer protocol.
-    pub fn filter_protocol(&self, conn: &ConnData, tracked: &S::Tracked) -> Actions {
+    pub fn filter_protocol(&self, conn: &ConnData, tracked: &mut S::Tracked) -> Actions {
         (self.proto_filter)(conn, tracked)
     }
 
@@ -141,7 +144,7 @@ where
         &self,
         session: &Session,
         conn: &ConnData,
-        tracked: &S::Tracked,
+        tracked: &mut S::Tracked,
     ) -> Actions {
         (self.session_filter)(session, conn, tracked)
     }

--- a/datatypes/src/lib.rs
+++ b/datatypes/src/lib.rs
@@ -99,17 +99,3 @@ pub trait FromSubscription {
     /// the constant value (e.g., matched filter string).
     fn from_subscription(spec: &SubscriptionSpec) -> proc_macro2::TokenStream;
 }
-
-/// Trait for a datatype that is built from a list of raw packets.
-pub trait PacketList {
-    /// Initialize internal data; called once per connection.
-    /// Note `first_pkt` will also be delivered to `update`.
-    fn new(first_pkt: &L4Pdu) -> Self;
-    /// New packet in connection received (or reassembled, if reassembled=true)
-    /// Note this may be invoked both pre- and post-reassembly; types
-    /// should check `reassembled` to avoid double-counting.
-    fn track_packet(&mut self, pdu: &L4Pdu, reassembled: bool);
-    /// Clear internal data; called if connection no longer matches filter
-    /// that requires the Tracked type.
-    fn clear(&mut self);
-}

--- a/datatypes/src/lib.rs
+++ b/datatypes/src/lib.rs
@@ -35,6 +35,9 @@ pub use static_type::*;
 pub mod packet_list;
 pub use packet_list::*;
 pub use typedefs::*;
+pub mod streaming;
+#[doc(hidden)]
+pub use streaming::CallbackTimer;
 
 use retina_core::conntrack::pdu::L4Pdu;
 use retina_core::filter::SubscriptionSpec;

--- a/datatypes/src/streaming.rs
+++ b/datatypes/src/streaming.rs
@@ -1,0 +1,128 @@
+use crate::Tracked;
+use retina_core::conntrack::pdu::L4Pdu;
+/// Infrastructure for managing the state of streaming subscriptions.
+/// This should not be accessed directly by the user.
+use retina_core::filter::datatypes::Streaming;
+use std::time::{Duration, Instant};
+
+/// Callback timer wrapper
+pub struct CallbackTimer<T>
+where
+    T: Tracked,
+{
+    /// The type of counter (time-based, packet-based, or byte-based)
+    counter_type: Streaming,
+    /// Whether a callback has "unsubscribed" from streaming data
+    unsubscribed: bool,
+    /// Whether the subscription's filter has matched
+    deliverable: bool,
+    /// For time-based counters, when the callback was last invoked
+    last_invoked: Option<Instant>,
+    /// For packet- and byte-based counters, the number of packets/bytes
+    /// remaining until the callback will be invoked again.
+    /// Can be set to 0 for time-based counters.
+    count_remaining: Option<u32>,
+    /// TMP - TODO move this into the TrackedWrapper to be shared
+    /// TODO - ideally could have multiple tracked datatypes
+    data: T,
+}
+
+impl<T> CallbackTimer<T>
+where
+    T: Tracked,
+{
+    /// Create a new CallbackTimer with the given counter type and data.
+    pub fn new(counter_type: Streaming, first_pkt: &L4Pdu) -> Self {
+        Self {
+            counter_type,
+            unsubscribed: false,
+            deliverable: false,
+            last_invoked: None,
+            count_remaining: None,
+            data: T::new(first_pkt),
+        }
+    }
+
+    /// Clear internal data.
+    /// Should be invoked after delivery.
+    #[inline]
+    pub fn clear(&mut self) {
+        self.data.clear();
+    }
+
+    #[inline]
+    pub fn update(&mut self, pdu: &L4Pdu, reassembled: bool) {
+        if !self.unsubscribed {
+            self.data.update(pdu, reassembled);
+        }
+    }
+
+    pub fn stream_protocols() -> Vec<&'static str> {
+        T::stream_protocols()
+    }
+
+    #[inline]
+    pub fn unsubscribe(&mut self) {
+        self.unsubscribed = true;
+    }
+
+    #[inline]
+    pub fn matched(&mut self) {
+        if !self.unsubscribed {
+            self.deliverable = true;
+        }
+    }
+
+    /// Check if the callback should be invoked. Update counters.
+    pub fn invoke(&mut self, pdu: &L4Pdu) -> bool {
+        if self.unsubscribed || !self.deliverable {
+            return false;
+        }
+        match self.counter_type {
+            Streaming::Seconds(duration) => {
+                // Deliver when first ready for delivery, then every N seconds
+                if self.last_invoked.is_none() {
+                    self.last_invoked = Some(Instant::now());
+                    return true;
+                }
+                if self.last_invoked.unwrap().elapsed()
+                    >= Duration::from_millis((duration * 1000.0).round() as u64)
+                {
+                    self.last_invoked = Some(Instant::now());
+                    return true;
+                }
+                false
+            }
+            Streaming::Packets(count) => {
+                // Deliver when first ready for delivery, then every N packets
+                if self.count_remaining.is_none() {
+                    self.count_remaining = Some(count);
+                    return true;
+                }
+                // New packet received
+                let count_remaining = self.count_remaining.unwrap();
+                if count_remaining == 1 {
+                    self.count_remaining = Some(count);
+                    return true;
+                }
+                self.count_remaining = Some(count_remaining - 1);
+                false
+            }
+            Streaming::Bytes(count) => {
+                // Deliver when first ready for delivery, then every N packets
+                if self.count_remaining.is_none() {
+                    self.count_remaining = Some(count);
+                    return true;
+                }
+                let count_remaining = self.count_remaining.unwrap();
+                let len = pdu.mbuf_ref().data_len() as u32;
+                if count_remaining <= len {
+                    self.count_remaining = Some(count);
+                    return true;
+                }
+                self.count_remaining = Some(count_remaining - len);
+                false
+            }
+        }
+    }
+}

--- a/datatypes/src/typedefs.rs
+++ b/datatypes/src/typedefs.rs
@@ -94,7 +94,7 @@ lazy_static! {
     ///
     /// For example: buffering packets may be required as a pre-match action for a
     /// packet-level datatype; it may also be required if one or more subscriptions request
-    /// a connection-level `PacketList`. Rather than maintaining these lists separately --
+    /// a connection-level `packet list`. Rather than maintaining these lists separately --
     /// one for filtering and one for delivery -- the tracked packets are stored once.
     ///
     /// Core ID is a special case, as it cannot be derived from connection,

--- a/examples/streaming/Cargo.toml
+++ b/examples/streaming/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "streaming"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+clap = { version = "3.2.23", features = ["derive"] }
+env_logger = "0.8.4"
+jsonl = "4.0.1"
+retina-core = { path = "../../core" }
+retina-filtergen = { path = "../../filtergen" }
+retina-datatypes = { path = "../../datatypes" }
+serde_json = "1.0.96"
+lazy_static = "1.4.0"
+array-init = "2.0"
+serde = { version = "1.0", features = ["derive"] }

--- a/examples/streaming/src/main.rs
+++ b/examples/streaming/src/main.rs
@@ -18,10 +18,10 @@ struct Args {
 /// following filter match (identification of TLS connection).
 /// That is, we expect the initial value of PktCount to be >3
 /// (after the TCP handshake and first data packet).
-#[filter("tls and tcp.port = 52152")]
+#[filter("tls")]
 #[streaming("packets=1")]
 fn tls_cb_pkts(pkts: &PktCount, ft: &FiveTuple) -> bool {
-    println!("{} Packet count: {}", ft, pkts.raw());
+    println!("{} Packet count: {:?}", ft, pkts);
     true
 }
 

--- a/examples/streaming/src/main.rs
+++ b/examples/streaming/src/main.rs
@@ -1,0 +1,48 @@
+use clap::Parser;
+/// An example to illustrate the streaming callback interface.
+use retina_core::{config::load_config, FiveTuple, Runtime};
+use retina_datatypes::*;
+use retina_filtergen::{filter, retina_main, streaming};
+use std::path::PathBuf;
+
+// Argument parsing
+#[derive(Parser, Debug)]
+struct Args {
+    #[clap(short, long, parse(from_os_str), value_name = "FILE")]
+    config: PathBuf,
+}
+
+/// This callback will be invoked on every packet for connections
+/// that are identified as TLS on TCP port 52152.
+/// The callback will begin to be invoked for the first packet
+/// following filter match (identification of TLS connection).
+/// That is, we expect the initial value of PktCount to be >3
+/// (after the TCP handshake and first data packet).
+#[filter("tls and tcp.port = 52152")]
+#[streaming("packets=1")]
+fn tls_cb_pkts(pkts: &PktCount, ft: &FiveTuple) -> bool {
+    println!("{} Packet count: {}", ft, pkts.raw());
+    true
+}
+
+/// This callback will be invoked every 5,000 bytes for connections
+/// that are identified as TLS and are not on TCP port 52152.
+/// Since the callback is invoked at most every packet, it may not
+/// be invoked at intervals of exactly 5,000 bytes.
+/// The "timer" for callback invocation will begin once the filter
+/// has matched; that is, the initial value of `bytes` will be >5,000
+/// as it will include the preamble *plus* ≥5,000 bytes of data.
+#[filter("tls and tcp.port != 52152")]
+#[streaming("bytes=5000")]
+fn tls_cb_bytes(bytes: &ByteCount, ft: &FiveTuple) -> bool {
+    println!("{} Byte count: {}", ft, bytes.raw());
+    true
+}
+
+#[retina_main(2)]
+fn main() {
+    let args = Args::parse();
+    let config = load_config(&args.config);
+    let mut runtime: Runtime<SubscribedWrapper> = Runtime::new(config, filter).unwrap();
+    runtime.run();
+}

--- a/filtergen/src/data.rs
+++ b/filtergen/src/data.rs
@@ -73,7 +73,7 @@ impl TrackedDataBuilder {
 
                 if datatype.needs_packet_track {
                     self.track_packet
-                        .push(quote! { self.#field_name.track_packet(pdu, reassembled); });
+                        .push(quote! { self.#field_name.update(pdu, reassembled); });
                     self.pkts_clear.push(quote! { self.#field_name.clear(); });
                 }
             }

--- a/filtergen/src/lib.rs
+++ b/filtergen/src/lib.rs
@@ -323,7 +323,7 @@ fn generate(input: syn::ItemFn, config: SubscriptionConfig) -> TokenStream {
         use retina_core::filter::{actions::*, datatypes::Streaming};
         // Import potentially-needed traits
         use retina_core::subscription::{Trackable, Subscribable};
-        use retina_datatypes::{FromSession, Tracked, FromMbuf, StaticData, PacketList};
+        use retina_datatypes::{FromSession, Tracked, FromMbuf, StaticData};
 
         #subscribable
 

--- a/filtergen/src/parse.rs
+++ b/filtergen/src/parse.rs
@@ -1,4 +1,4 @@
-use retina_core::filter::SubscriptionSpec;
+use retina_core::filter::{datatypes::Streaming, Level, SubscriptionSpec};
 use retina_datatypes::DATATYPES;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
@@ -16,6 +16,7 @@ pub(crate) struct SubscriptionRaw {
     #[serde_as(as = "serde_with::OneOrMany<_>")]
     pub(crate) datatypes: Vec<String>,
     pub(crate) callback: String,
+    pub(crate) streaming: Option<Streaming>,
 }
 
 #[derive(Debug, Clone)]
@@ -29,6 +30,9 @@ impl SubscriptionConfig {
         for s in &config.subscriptions {
             assert!(!s.datatypes.is_empty());
             let mut spec = SubscriptionSpec::new(s.filter.clone(), s.callback.clone());
+            if let Some(streaming) = s.streaming {
+                spec.level = Level::Streaming(streaming);
+            }
             for datatype_str in &s.datatypes {
                 Self::validate_datatype(datatype_str.as_str());
                 let datatype = DATATYPES.get(datatype_str.as_str()).unwrap().clone();

--- a/filtergen/src/utils.rs
+++ b/filtergen/src/utils.rs
@@ -270,9 +270,16 @@ pub(crate) fn update_body(
                 if matches!(spec.level, Level::Packet) {
                     body.push(build_packet_callback(spec, filter_layer));
                 } else {
-                    body.push(build_callback(spec, filter_layer, session_loop));
+                    body.push(build_callback(spec, filter_layer, session_loop, false));
                 }
             }
+        }
+    }
+    if !node.stream.is_empty() {
+        for s in &node.stream {
+            let id = format!("streaming_{}", s.id);
+            let field_name = Ident::new(&id, Span::call_site());
+            body.push(quote! { tracked.#field_name.matched(); });
         }
     }
 }


### PR DESCRIPTION
This PR introduces an interface for specifying that a callback should be invoked every N packets, seconds, or bytes. 

There's a lot more to do to finish out streaming callbacks -- allowing for a mutable datatype and multiple streaming parameters are the two main things -- but I think that this initial version works, and I'd like to get it into main so that folks can start to try it out. 